### PR TITLE
update global params interface when inserting

### DIFF
--- a/internal/clients/bbnclient/bbnclient.go
+++ b/internal/clients/bbnclient/bbnclient.go
@@ -66,7 +66,7 @@ func (c *BbnClient) GetCheckpointParams(ctx context.Context) (*CheckpointParams,
 			fmt.Sprintf("failed to validate checkpoint params: %s", err.Error()),
 		)
 	}
-	return &params.Params, nil
+	return FromBbnCheckpointParams(params.Params), nil
 }
 
 func (c *BbnClient) GetAllStakingParams(ctx context.Context) (map[uint32]*StakingParams, *types.Error) {

--- a/internal/clients/bbnclient/types.go
+++ b/internal/clients/bbnclient/types.go
@@ -10,20 +10,26 @@ import (
 // StakingParams represents the staking parameters of the BBN chain
 // Reference: https://github.com/babylonlabs-io/babylon/blob/main/proto/babylon/btcstaking/v1/params.proto
 type StakingParams struct {
-	CovenantPks                  []string
-	CovenantQuorum               uint32
-	MinStakingValueSat           int64
-	MaxStakingValueSat           int64
-	MinStakingTimeBlocks         uint32
-	MaxStakingTimeBlocks         uint32
-	SlashingPkScript             string
-	MinSlashingTxFeeSat          int64
-	SlashingRate                 string
-	MinUnbondingTimeBlocks       uint32
-	UnbondingFeeSat              int64
-	MinCommissionRate            string
-	MaxActiveFinalityProviders   uint32
-	DelegationCreationBaseGasFee uint64
+	CovenantPks                  []string `bson:"covenant_pks"`
+	CovenantQuorum               uint32   `bson:"covenant_quorum"`
+	MinStakingValueSat           int64    `bson:"min_staking_value_sat"`
+	MaxStakingValueSat           int64    `bson:"max_staking_value_sat"`
+	MinStakingTimeBlocks         uint32   `bson:"min_staking_time_blocks"`
+	MaxStakingTimeBlocks         uint32   `bson:"max_staking_time_blocks"`
+	SlashingPkScript             string   `bson:"slashing_pk_script"`
+	MinSlashingTxFeeSat          int64    `bson:"min_slashing_tx_fee_sat"`
+	SlashingRate                 string   `bson:"slashing_rate"`
+	MinUnbondingTimeBlocks       uint32   `bson:"min_unbonding_time_blocks"`
+	UnbondingFeeSat              int64    `bson:"unbonding_fee_sat"`
+	MinCommissionRate            string   `bson:"min_commission_rate"`
+	MaxActiveFinalityProviders   uint32   `bson:"max_active_finality_providers"`
+	DelegationCreationBaseGasFee uint64   `bson:"delegation_creation_base_gas_fee"`
+}
+
+type CheckpointParams struct {
+	BtcConfirmationDepth          uint64 `bson:"btc_confirmation_depth"`
+	CheckpointFinalizationTimeout uint64 `bson:"checkpoint_finalization_timeout"`
+	CheckpointTag                 string `bson:"checkpoint_tag"`
 }
 
 func FromBbnStakingParams(params stakingtypes.Params) *StakingParams {
@@ -45,4 +51,10 @@ func FromBbnStakingParams(params stakingtypes.Params) *StakingParams {
 	}
 }
 
-type CheckpointParams = checkpointtypes.Params
+func FromBbnCheckpointParams(params checkpointtypes.Params) *CheckpointParams {
+	return &CheckpointParams{
+		BtcConfirmationDepth:          params.BtcConfirmationDepth,
+		CheckpointFinalizationTimeout: params.CheckpointFinalizationTimeout,
+		CheckpointTag:                 params.CheckpointTag,
+	}
+}


### PR DESCRIPTION
<img width="765" alt="Screenshot 2024-10-29 at 3 22 07 PM" src="https://github.com/user-attachments/assets/cedcbb01-23b5-44a7-81c8-9bfd561b636e">

currently, the field names are not separated by "_"