### PR TITLE
fix: panic in process methods

### DIFF
--- a/internal/services/delegation.go
+++ b/internal/services/delegation.go
@@ -160,10 +160,21 @@ func (s *Service) processBTCDelegationInclusionProofReceivedEvent(
 func (s *Service) processBTCDelegationUnbondedEarlyEvent(
 	ctx context.Context, event abcitypes.Event,
 ) *types.Error {
-	// Parse and validate event
-	unbondedEarlyEvent, err := s.parseAndValidateUnbondedEarlyEvent(ctx, event)
+	unbondedEarlyEvent, err := parseEvent[*bbntypes.EventBTCDelgationUnbondedEarly](
+		EventBTCDelgationUnbondedEarly,
+		event,
+	)
 	if err != nil {
 		return err
+	}
+
+	shouldProcess, err := s.validateBTCDelegationUnbondedEarlyEvent(ctx, unbondedEarlyEvent)
+	if err != nil {
+		return err
+	}
+	if !shouldProcess {
+		// Event is valid but should be skipped
+		return nil
 	}
 
 	// Get delegation details
@@ -193,10 +204,21 @@ func (s *Service) processBTCDelegationUnbondedEarlyEvent(
 func (s *Service) processBTCDelegationExpiredEvent(
 	ctx context.Context, event abcitypes.Event,
 ) *types.Error {
-	// Parse and validate event
-	expiredEvent, err := s.parseAndValidateExpiredEvent(ctx, event)
+	expiredEvent, err := parseEvent[*bbntypes.EventBTCDelegationExpired](
+		EventBTCDelegationExpired,
+		event,
+	)
 	if err != nil {
 		return err
+	}
+
+	shouldProcess, err := s.validateBTCDelegationExpiredEvent(ctx, expiredEvent)
+	if err != nil {
+		return err
+	}
+	if !shouldProcess {
+		// Event is valid but should be skipped
+		return nil
 	}
 
 	// Get delegation details

--- a/internal/services/events.go
+++ b/internal/services/events.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/babylonlabs-io/babylon-staking-indexer/internal/types"
-	bbntypes "github.com/babylonlabs-io/babylon/x/btcstaking/types"
 	abcitypes "github.com/cometbft/cometbft/abci/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	proto "github.com/cosmos/gogoproto/proto"
@@ -134,52 +133,4 @@ func parseEvent[T proto.Message](
 	}
 
 	return concreteMsg, nil
-}
-
-func (s *Service) parseAndValidateUnbondedEarlyEvent(
-	ctx context.Context,
-	event abcitypes.Event,
-) (*bbntypes.EventBTCDelgationUnbondedEarly, *types.Error) {
-	// Parse event
-	unbondedEarlyEvent, err := parseEvent[*bbntypes.EventBTCDelgationUnbondedEarly](
-		EventBTCDelgationUnbondedEarly,
-		event,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	// Validate event
-	proceed, err := s.validateBTCDelegationUnbondedEarlyEvent(ctx, unbondedEarlyEvent)
-	if err != nil {
-		return nil, err
-	}
-	if !proceed {
-		return nil, nil
-	}
-
-	return unbondedEarlyEvent, nil
-}
-
-func (s *Service) parseAndValidateExpiredEvent(
-	ctx context.Context,
-	event abcitypes.Event,
-) (*bbntypes.EventBTCDelegationExpired, *types.Error) {
-	expiredEvent, err := parseEvent[*bbntypes.EventBTCDelegationExpired](
-		EventBTCDelegationExpired,
-		event,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	proceed, err := s.validateBTCDelegationExpiredEvent(ctx, expiredEvent)
-	if err != nil {
-		return nil, err
-	}
-	if !proceed {
-		return nil, nil
-	}
-
-	return expiredEvent, nil
 }


### PR DESCRIPTION
Noticed errors in process method

```
"level":"debug","stakingTxHashHex":"3a0e302b928558ae2830a6f3b8179e8f7762d6681f4a5a377ee184410da4af52","currentState":"VERIFIED","time":"2024-11-14T16:07:05Z","message":"Ignoring EventBTCDelgationUnbondedEarly because current state is not qualified for transition"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x276936e]

goroutine 1 [running]:
github.com/babylonlabs-io/babylon-staking-indexer/internal/services.(*Service).processBTCDelegationUnbondedEarlyEvent(0xc001348080, {0x38bb690, 0x550ca60}, {{0xc001c81400, 0x34}, {0xc002cdf220, 0x4, 0x4}})
	/go/src/github.com/babylonlabs-io/babylon-staking-indexer/internal/services/delegation.go:170 +0x6e
github.com/babylonlabs-io/babylon-staking-indexer/internal/services.(*Service).processEvent(0xc001348080, {0x38bb690, 0x550ca60}, {{0x2f1dcf6, 0x2}, {{0xc001c81400, 0x34}, {0xc002cdf220, 0x4, 0x4}}})
	/go/src/github.com/babylonlabs-io/babylon-staking-indexer/internal/services/events.go:70 +0x33b
github.com/babylonlabs-io/babylon-staking-indexer/internal/services.(*Service).processBlocksSequentially(0xc001348080, {0x38bb690, 0x550ca60})
	/go/src/github.com/babylonlabs-io/babylon-staking-indexer/internal/services/bootstrap.go:79 +0x54c
github.com/babylonlabs-io/babylon-staking-indexer/internal/services.(*Service).StartBbnBlockProcessor(0xc001348080?, {0x38bb690?, 0x550ca60?})
	/go/src/github.com/babylonlabs-io/babylon-staking-indexer/internal/services/bootstrap.go:22 +0x1d
github.com/babylonlabs-io/babylon-staking-indexer/internal/services.(*Service).StartIndexerSync(0xc001348080, {0x38bb690, 0x550ca60})
	/go/src/github.com/babylonlabs-io/babylon-staking-indexer/internal/services/service.go:70 +0x10d
main.main()
	/go/src/github.com/babylonlabs-io/babylon-staking-indexer/cmd/babylon-staking-indexer/main.go:76 +0x528
```