### PR TITLE
CI: Enable Dockerfile and image scanning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,8 +17,12 @@ jobs:
      
   docker_pipeline:
     needs: ["lint_test"]
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.6.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.12.2
     secrets: inherit
     with:
      publish: true
      dockerfile: ./contrib/images/babylon-staking-indexer/Dockerfile
+     docker_scan: true
+    permissions:
+      security-events: write
+      packages: read

--- a/contrib/images/babylon-staking-indexer/Dockerfile
+++ b/contrib/images/babylon-staking-indexer/Dockerfile
@@ -1,7 +1,8 @@
-FROM golang:1.22.3-alpine AS builder
+FROM golang:1.22.7-alpine AS builder
 
 ARG VERSION="HEAD"
 
+# hadolint ignore=DL3018
 RUN apk add --no-cache  \
     make \
     git \
@@ -12,7 +13,7 @@ RUN apk add --no-cache  \
     alpine-sdk \
     libsodium-dev \
     libsodium-static \
-    openssh
+   openssh && rm -rf /var/cache/apk/*
 
 # Build
 WORKDIR /go/src/github.com/babylonlabs-io/babylon-staking-indexer
@@ -31,10 +32,11 @@ RUN LDFLAGS='-extldflags "-static" -v' \
     make build
 
 # Final minimal image with binary only
-FROM alpine:3.16 as run
+FROM alpine:3.20 as run
 
-RUN addgroup --gid 1138 -S babylon-staking-indexer && adduser --uid 1138 -S babylon-staking-indexer -G babylon-staking-indexer
-RUN apk add bash curl jq
+# hadolint ignore=DL3018
+RUN addgroup --gid 1138 -S babylon-staking-indexer && adduser --uid 1138 -S babylon-staking-indexer -G babylon-staking-indexer \
+ && apk add --no-cache bash curl jq && rm -rf /var/cache/apk/*
 
 # Label should match your github repo
 LABEL org.opencontainers.image.source="https://github.com/babylonlabs-io/babylon-staking-indexer:${VERSION}"


### PR DESCRIPTION
Some remaining CVE that may need analyzed:
<table>
    <tr>
        <th>Package</th>
        <th>ID</th>
        <th>Severity</th>
        <th>Installed Version</th>
        <th>Fixed Version</th>
    </tr>
    <tr>
        <td><code>github.com/cometbft/cometbft</code></td>
        <td>GHSA-p7mv-53f2-4cwj</td>
        <td>HIGH</td>
        <td>v0.38.9</td>
        <td>0.38.15</td>
    </tr>
    <tr>
        <td><code>github.com/cometbft/cometbft</code></td>
        <td>GHSA-g5xx-c4hv-9ccc</td>
        <td>MEDIUM</td>
        <td>v0.38.9</td>
        <td>0.37.11, 0.38.12</td>
    </tr>
    <tr>
        <td><code>github.com/ethereum/go-ethereum</code></td>
        <td>CVE-2024-32972</td>
        <td>HIGH</td>
        <td>v1.13.14</td>
        <td>1.13.15</td>
    </tr>
</table>