### PR TITLE
fix: issue in state transition

### DIFF
--- a/internal/db/model/delegation.go
+++ b/internal/db/model/delegation.go
@@ -98,6 +98,7 @@ func FromEventBTCDelegationInclusionProofReceived(
 	return &BTCDelegationDetails{
 		StartHeight: uint32(startHeight),
 		EndHeight:   uint32(endHeight),
+		State:       types.DelegationState(event.NewState),
 	}
 }
 

--- a/internal/services/expiry_checker.go
+++ b/internal/services/expiry_checker.go
@@ -45,7 +45,7 @@ func (s *Service) checkExpiry(ctx context.Context) *types.Error {
 		}
 
 		// Check if the delegation is in a qualified state to transition to Withdrawable
-		if !utils.Contains(types.QualifiedStatesForExpired(), delegation.State) {
+		if !utils.Contains(types.QualifiedStatesForWithdrawable(), delegation.State) {
 			log.Debug().
 				Str("stakingTxHashHex", delegation.StakingTxHashHex).
 				Str("currentState", delegation.State.String()).

--- a/internal/types/state.go
+++ b/internal/types/state.go
@@ -51,17 +51,12 @@ func QualifiedStatesForExpired() []DelegationState {
 	return []DelegationState{StateActive}
 }
 
-// QualifiedStatesForPendingBTCConfirmation returns the qualified current states for PendingBTCConfirmation event
-func QualifiedStatesForPendingBTCConfirmation() []DelegationState {
-	return []DelegationState{StatePending}
-}
-
-// QualifiedStatesForUnbondingSubmitted returns the qualified current states for UnbondingSubmitted event
-func QualifiedStatesForUnbondingSubmitted() []DelegationState {
-	return []DelegationState{StateActive}
-}
-
 // QualifiedStatesForWithdrawn returns the qualified current states for Withdrawn event
 func QualifiedStatesForWithdrawn() []DelegationState {
 	return []DelegationState{StateWithdrawable}
+}
+
+// QualifiedStatesForWithdrawable returns the qualified current states for Withdrawable event
+func QualifiedStatesForWithdrawable() []DelegationState {
+	return []DelegationState{StateUnbonding}
 }


### PR DESCRIPTION
Fixes - https://github.com/babylonlabs-io/babylon-staking-indexer/issues/50

Verifier -> Active state transition was not happening, due to which we saw those logs