### PR TITLE
fix: sanitise event of double quotes before processing

### DIFF
--- a/internal/services/events.go
+++ b/internal/services/events.go
@@ -60,9 +60,7 @@ func (s *Service) processEvent(
 		err = s.processFinalityProviderEditedEvent(ctx, bbnEvent)
 	case EventFinalityProviderStatusChange:
 		log.Debug().Msg("Processing finality provider status change event")
-		// TODO: fix error from this event
-		// https://github.com/babylonlabs-io/babylon-staking-indexer/issues/24
-		s.processFinalityProviderStateChangeEvent(ctx, bbnEvent)
+		err = s.processFinalityProviderStateChangeEvent(ctx, bbnEvent)
 	case EventBTCDelegationCreated:
 		log.Debug().Msg("Processing new BTC delegation event")
 		err = s.processNewBTCDelegationEvent(ctx, bbnEvent, blockHeight)


### PR DESCRIPTION
```
{"level":"debug","raw_event":{"type":"babylon.btcstaking.v1.EventBTCDelegationExpired","attributes":[{"key":"new_state","value":"\"UNBONDED\"","index":true},{"key":"staking_tx_hash","value":"\"3249d29bb307f2959413b1f76532f23d3d001a8d00f953455fffc41c7db43e5d\"","index":true},{"key":"mode","value":"BeginBlock","index":true}]},"time":"2024-11-22T01:06:16+11:00","message":"Raw event data"}
{"level":"error","error":"failed to parse typed event: json: error calling MarshalJSON for type json.RawMessage: invalid character 'B' looking for beginning of value","time":"2024-11-22T01:06:16+11:00","message":"Failed to process event"}

```

The issue is `BeginBlock` field does not have the "\" thing in its value