### PR TITLE
fix: parsing in staking params

### DIFF
--- a/internal/clients/bbnclient/types.go
+++ b/internal/clients/bbnclient/types.go
@@ -23,6 +23,7 @@ type StakingParams struct {
 	UnbondingFeeSat              int64    `bson:"unbonding_fee_sat"`
 	MinCommissionRate            string   `bson:"min_commission_rate"`
 	DelegationCreationBaseGasFee uint64   `bson:"delegation_creation_base_gas_fee"`
+	AllowListExpirationHeight    uint64   `bson:"allow_list_expiration_height"`
 }
 
 type CheckpointParams struct {
@@ -46,6 +47,7 @@ func FromBbnStakingParams(params stakingtypes.Params) *StakingParams {
 		UnbondingFeeSat:              params.UnbondingFeeSat,
 		MinCommissionRate:            params.MinCommissionRate.String(),
 		DelegationCreationBaseGasFee: params.DelegationCreationBaseGasFee,
+		AllowListExpirationHeight:    params.AllowListExpirationHeight,
 	}
 }
 

--- a/internal/db/model/params.go
+++ b/internal/db/model/params.go
@@ -1,7 +1,21 @@
 package model
 
-type GlobalParamsDocument struct {
-	Type    string      `bson:"type"`
-	Version uint32      `bson:"version"`
-	Params  interface{} `bson:"params"`
+import "github.com/babylonlabs-io/babylon-staking-indexer/internal/clients/bbnclient"
+
+// Base document for common fields
+type BaseParamsDocument struct {
+	Type    string `bson:"type"`
+	Version uint32 `bson:"version"`
+}
+
+// Specific document for staking params
+type StakingParamsDocument struct {
+	BaseParamsDocument `bson:",inline"`
+	Params             *bbnclient.StakingParams `bson:"params"`
+}
+
+// Specific document for checkpoint params
+type CheckpointParamsDocument struct {
+	BaseParamsDocument `bson:",inline"`
+	Params             *bbnclient.CheckpointParams `bson:"params"`
 }


### PR DESCRIPTION
Fixes
https://github.com/babylonlabs-io/babylon-staking-indexer/issues/40
https://github.com/babylonlabs-io/babylon-staking-indexer/issues/63

The params was interface earlier and wrongly typecasted. This pr makes concrete types and stores as separate documents