### PR TITLE
chore: bump queue client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.1
 require (
 	github.com/avast/retry-go/v4 v4.5.1
 	github.com/babylonlabs-io/babylon v0.18.0
-	github.com/babylonlabs-io/staking-queue-client v0.4.7-0.20241212104643-06828f6e25d5
+	github.com/babylonlabs-io/staking-queue-client v0.4.7-0.20241212112557-9ac7de686075
 	github.com/btcsuite/btcd v0.24.3-0.20241011125836-24eb815168f4
 	github.com/btcsuite/btcd/btcec/v2 v2.3.4
 	github.com/btcsuite/btcd/btcutil v1.1.6

--- a/go.sum
+++ b/go.sum
@@ -286,6 +286,8 @@ github.com/babylonlabs-io/staking-queue-client v0.4.7-0.20241203052145-e50972fc1
 github.com/babylonlabs-io/staking-queue-client v0.4.7-0.20241203052145-e50972fc19c9/go.mod h1:n3fr3c+9LNiJlyETmcrVk94Zn76rAADhGZKxX+rVf+Q=
 github.com/babylonlabs-io/staking-queue-client v0.4.7-0.20241212104643-06828f6e25d5 h1:b89cYr2MuW8bzKDVIHT8kPKD1dQygCERYpTtR8eGmcY=
 github.com/babylonlabs-io/staking-queue-client v0.4.7-0.20241212104643-06828f6e25d5/go.mod h1:n3fr3c+9LNiJlyETmcrVk94Zn76rAADhGZKxX+rVf+Q=
+github.com/babylonlabs-io/staking-queue-client v0.4.7-0.20241212112557-9ac7de686075 h1:gB+jslBkK5/ror4sn9NHldKjLu4nE88jgD43d2L3osc=
+github.com/babylonlabs-io/staking-queue-client v0.4.7-0.20241212112557-9ac7de686075/go.mod h1:n3fr3c+9LNiJlyETmcrVk94Zn76rAADhGZKxX+rVf+Q=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=


### PR DESCRIPTION
Fixes - https://github.com/babylonlabs-io/babylon-staking-indexer/issues/86
