### PR TITLE
fix: skip slashing event for delegations w/o inclusion proof

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - 'main'
-    - 'gusin13/stats-fix-2'
     tags:
     - '*'
 


### PR DESCRIPTION
Fixes - https://github.com/babylonlabs-io/staking-api-service/issues/176

Its possible for delegations to be slashed (even if they don't have inclusion proof i.e they are not submitted to btc)

This edge case has led to wrong calculation in stats, b/c the slashed event will lead to subtraction but the delegation was never active so the tvl etc will be negative 