### PR TITLE
fix: err in deleting timelock expiry documents

### DIFF
--- a/internal/db/timelock.go
+++ b/internal/db/timelock.go
@@ -44,7 +44,7 @@ func (db *Database) FindExpiredDelegations(ctx context.Context, btcTipHeight, li
 
 func (db *Database) DeleteExpiredDelegation(ctx context.Context, stakingTxHashHex string) error {
 	client := db.client.Database(db.dbName).Collection(model.TimeLockCollection)
-	filter := bson.M{"_id": stakingTxHashHex}
+	filter := bson.M{"staking_tx_hash_hex": stakingTxHashHex}
 
 	result, err := client.DeleteOne(ctx, filter)
 	if err != nil {


### PR DESCRIPTION
```
{
  "level": "error",
  "error": "failed to delete expired delegation: no expired delegation found with stakingTxHashHex ae092b1ddd8bf135b6ca9c45e6a9c73a9745f9733563b04bdfd88c5e7db124af",
  "time": "2025-01-07T06:40:33Z",
  "message": "Error polling"
}
```