### PR TITLE
fix: btc notification resubscription

### DIFF
--- a/internal/services/expiry_checker.go
+++ b/internal/services/expiry_checker.go
@@ -63,7 +63,7 @@ func (s *Service) checkExpiry(ctx context.Context) *types.Error {
 			if db.IsNotFoundError(stateUpdateErr) {
 				log.Debug().
 					Str("staking_tx", delegation.StakingTxHashHex).
-					Msg("Skip updating BTC delegation state to withdrawable as the it's outdated")
+					Msg("skip updating BTC delegation state to withdrawable as the state is not qualified")
 			} else {
 				log.Error().
 					Str("staking_tx", delegation.StakingTxHashHex).


### PR DESCRIPTION
- Active, Unbonding, Withdrawable, Slashed states need to be resubscribed on restart
- Skip delegations w/o inclusion proof (i.e don't have start/end height)