### PR TITLE
fix: unused defer

### DIFF
--- a/internal/services/watch_btc_events.go
+++ b/internal/services/watch_btc_events.go
@@ -25,7 +25,6 @@ func (s *Service) watchForSpendStakingTx(
 	spendEvent *notifier.SpendEvent,
 	stakingTxHashHex string,
 ) {
-	defer s.wg.Done()
 	quitCtx, cancel := s.quitContext()
 	defer cancel()
 


### PR DESCRIPTION
go routine is being setup in the caller, defer is already there