### PR TITLE
Trigger mock generations through go generate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,8 @@ run-local:
 	./bin/local-startup.sh;
 	go run cmd/babylon-staking-indexer/main.go --config config/config-local.yml
 
-generate-mock-interface:
-	cd internal/db && mockery --name=DbInterface --output=../../tests/mocks --outpkg=mocks --filename=mock_db_client.go
-	cd internal/clients/btcclient && mockery --name=BtcInterface --output=../../../tests/mocks --outpkg=mocks --filename=mock_btc_client.go
-	cd internal/clients/bbnclient && mockery --name=BbnInterface --output=../../../tests/mocks --outpkg=mocks --filename=mock_bbn_client.go
+generate:
+	go generate ./...
 
 test:
 	./bin/local-startup.sh;

--- a/internal/clients/bbnclient/interface.go
+++ b/internal/clients/bbnclient/interface.go
@@ -6,6 +6,7 @@ import (
 	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 )
 
+//go:generate mockery --name=BbnInterface --output=../../../tests/mocks --outpkg=mocks --filename=mock_bbn_client.go
 type BbnInterface interface {
 	GetCheckpointParams(ctx context.Context) (*CheckpointParams, error)
 	GetAllStakingParams(ctx context.Context) (map[uint32]*StakingParams, error)

--- a/internal/clients/btcclient/interface.go
+++ b/internal/clients/btcclient/interface.go
@@ -1,5 +1,6 @@
 package btcclient
 
+//go:generate mockery --name=BtcInterface --output=../../../tests/mocks --outpkg=mocks --filename=mock_btc_client.go
 type BtcInterface interface {
 	GetTipHeight() (uint64, error)
 }

--- a/internal/db/interface.go
+++ b/internal/db/interface.go
@@ -8,6 +8,7 @@ import (
 	"github.com/babylonlabs-io/babylon-staking-indexer/internal/types"
 )
 
+//go:generate mockery --name=DbInterface --output=../../tests/mocks --outpkg=mocks --filename=mock_db_client.go
 type DbInterface interface {
 	/**
 	 * Ping checks the database connection.


### PR DESCRIPTION
`go generate` is a [special command in golang](https://go.dev/blog/generate) suite that goes through whole codebase and looking for `//go:generate <shell command>` comments and call every command specified in a comment one by one.

