### PR TITLE
Replace .Str()+strconv.Format() in logs with .Uint32 for uint32 types

### DIFF
--- a/internal/services/delegation.go
+++ b/internal/services/delegation.go
@@ -154,7 +154,7 @@ func (s *Service) processCovenantQuorumReachedEvent(
 	if newState == types.StateActive {
 		log.Debug().
 			Str("staking_tx", covenantQuorumReachedEvent.StakingTxHash).
-			Str("staking_start_height", strconv.FormatUint(uint64(delegation.StartHeight), 10)).
+			Uint32("staking_start_height", delegation.StartHeight).
 			Stringer("event_type", EventCovenantQuorumReached).
 			Msg("handling active state")
 
@@ -338,8 +338,8 @@ func (s *Service) processBTCDelegationUnbondedEarlyEvent(
 		Str("staking_tx", unbondedEarlyEvent.StakingTxHash).
 		Stringer("new_state", types.StateUnbonding).
 		Str("early_unbonding_start_height", unbondedEarlyEvent.StartHeight).
-		Str("unbonding_time", strconv.FormatUint(uint64(delegation.UnbondingTime), 10)).
-		Str("unbonding_expire_height", strconv.FormatUint(uint64(unbondingExpireHeight), 10)).
+		Uint32("unbonding_time", delegation.UnbondingTime).
+		Uint32("unbonding_expire_height", unbondingExpireHeight).
 		Stringer("sub_state", subState).
 		Stringer("event_type", EventBTCDelgationUnbondedEarly).
 		Msg("updating delegation state")

--- a/internal/services/expiry_checker.go
+++ b/internal/services/expiry_checker.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strconv"
-
 	"github.com/babylonlabs-io/babylon-staking-indexer/internal/db"
 	"github.com/babylonlabs-io/babylon-staking-indexer/internal/types"
 	"github.com/babylonlabs-io/babylon-staking-indexer/internal/utils/poller"
@@ -49,7 +47,7 @@ func (s *Service) checkExpiry(ctx context.Context) *types.Error {
 			Str("staking_tx", delegation.StakingTxHashHex).
 			Stringer("current_state", delegation.State).
 			Stringer("new_sub_state", tlDoc.DelegationSubState).
-			Str("expire_height", strconv.FormatUint(uint64(tlDoc.ExpireHeight), 10)).
+			Uint32("expire_height", tlDoc.ExpireHeight).
 			Msg("checking if delegation is expired")
 
 		stateUpdateErr := s.db.UpdateBTCDelegationState(


### PR DESCRIPTION
`Uint32()` implementation:
```
...
e.buf = enc.AppendUint32(enc.AppendKey(e.buf, key), i)
...
```
`AppendUint32()` in turn calls `strconv.AppendUint(dst, uint64(val), 10)` (mind base=10 as we used before).
From `AppendUint()` godoc:

// AppendUint appends the string form of the unsigned integer i,
// **as generated by [FormatUint]**, to dst and returns the extended buffer.