### PR TITLE
Reduce number of log.Fatal calls

### DIFF
--- a/cmd/babylon-staking-indexer/cli/fill_staker_addr.go
+++ b/cmd/babylon-staking-indexer/cli/fill_staker_addr.go
@@ -58,7 +58,10 @@ func fillStakerAddrE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	bbnClient := bbnclient.NewBBNClient(&cfg.BBN)
+	bbnClient, err := bbnclient.NewBBNClient(&cfg.BBN)
+	if err != nil {
+		return err
+	}
 	srv := services.NewService(cfg, dbClient, nil, nil, bbnClient, nil)
 
 	return srv.FillStakerAddr(ctx, numWorkers, dryRun)

--- a/cmd/babylon-staking-indexer/main.go
+++ b/cmd/babylon-staking-indexer/main.go
@@ -80,7 +80,10 @@ func main() {
 	}
 	btcClient = btcclient.NewBTCClientWithMetrics(btcClient)
 
-	bbnClient := bbnclient.NewBBNClient(&cfg.BBN)
+	bbnClient, err := bbnclient.NewBBNClient(&cfg.BBN)
+	if err != nil {
+		log.Fatal().Err(err).Msg("error while creating BBN query client")
+	}
 	bbnClient = bbnclient.NewBBNClientWithMetrics(bbnClient)
 
 	btcNotifier, err := btcclient.NewBTCNotifier(
@@ -100,5 +103,8 @@ func main() {
 	metricsPort := cfg.Metrics.GetMetricsPort()
 	metrics.Init(metricsPort)
 
-	service.StartIndexerSync(ctx)
+	err = service.StartIndexerSync(ctx)
+	if err != nil {
+		log.Fatal().Err(err).Msg("error while starting indexer sync")
+	}
 }

--- a/e2etest/test_manager.go
+++ b/e2etest/test_manager.go
@@ -148,7 +148,8 @@ func StartManager(t *testing.T, numMatureOutputsInWallet uint32, epochInterval u
 	require.NoError(t, err)
 
 	cfg.BBN.RPCAddr = fmt.Sprintf("http://localhost:%s", babylond.GetPort("26657/tcp"))
-	bbnClient := indexerbbnclient.NewBBNClient(&cfg.BBN)
+	bbnClient, err := indexerbbnclient.NewBBNClient(&cfg.BBN)
+	require.NoError(t, err)
 
 	service := services.NewService(cfg, dbClient, btcClient, btcNotifier, bbnClient, queueConsumer)
 	require.NoError(t, err)
@@ -163,7 +164,11 @@ func StartManager(t *testing.T, numMatureOutputsInWallet uint32, epochInterval u
 	unbondingStakingEventChan, err := queueConsumer.UnbondingStakingQueue.ReceiveMessages()
 	require.NoError(t, err)
 
-	go service.StartIndexerSync(ctx)
+	go func() {
+		err := service.StartIndexerSync(ctx)
+		require.NoError(t, err)
+	}()
+
 	// Wait for the server to start
 	time.Sleep(3 * time.Second)
 

--- a/internal/clients/bbnclient/bbnclient.go
+++ b/internal/clients/bbnclient/bbnclient.go
@@ -21,7 +21,7 @@ type BBNClient struct {
 	cfg         *config.BBNConfig
 }
 
-func NewBBNClient(cfg *config.BBNConfig) BbnInterface {
+func NewBBNClient(cfg *config.BBNConfig) (BbnInterface, error) {
 	bbnQueryCfg := &bbncfg.BabylonQueryConfig{
 		RPCAddr: cfg.RPCAddr,
 		Timeout: cfg.Timeout,
@@ -29,12 +29,13 @@ func NewBBNClient(cfg *config.BBNConfig) BbnInterface {
 
 	queryClient, err := query.New(bbnQueryCfg)
 	if err != nil {
-		log.Fatal().Err(err).Msg("error while creating BBN query client")
+		return nil, err
+
 	}
 	return &BBNClient{
 		queryClient: queryClient,
 		cfg:         cfg,
-	}
+	}, nil
 }
 
 func (c *BBNClient) GetLatestBlockNumber(ctx context.Context) (int64, error) {

--- a/internal/services/bootstrap.go
+++ b/internal/services/bootstrap.go
@@ -18,10 +18,12 @@ const (
 // It continuously processes new blocks and their events sequentially, maintaining the chain order.
 // If an error occurs, it logs the error and terminates the program.
 // The method runs asynchronously to allow non-blocking operation.
-func (s *Service) StartBbnBlockProcessor(ctx context.Context) {
+func (s *Service) StartBbnBlockProcessor(ctx context.Context) error {
 	if err := s.processBlocksSequentially(ctx); err != nil {
-		log.Fatal().Msgf("BBN block processor exited with error: %v", err)
+		return fmt.Errorf("BBN block processor exited with error: %w", err)
 	}
+
+	return nil
 }
 
 // FillStakerAddr is temporary method to backfill staker_addr data in the database.

--- a/internal/services/subscription.go
+++ b/internal/services/subscription.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"fmt"
 	"github.com/babylonlabs-io/babylon-staking-indexer/internal/types"
 	ctypes "github.com/cometbft/cometbft/types"
 	"github.com/rs/zerolog/log"
@@ -17,10 +18,10 @@ const (
 	maxEventWaitInterval            = 1 * time.Minute
 )
 
-func (s *Service) SubscribeToBbnEvents(ctx context.Context) {
+func (s *Service) SubscribeToBbnEvents(ctx context.Context) error {
 	log := log.Ctx(ctx)
 	if !s.bbn.IsRunning() {
-		log.Fatal().Msg("BBN client is not running")
+		return fmt.Errorf("BBN client is not running")
 	}
 	// Subscribe to new block events but only wait for 5 minutes for events
 	// if nothing come through within 5 minutes, the underlying subscription will
@@ -37,7 +38,7 @@ func (s *Service) SubscribeToBbnEvents(ctx context.Context) {
 		outCapacity,
 	)
 	if err != nil {
-		log.Fatal().Msgf("Failed to subscribe to events: %v", err)
+		return fmt.Errorf("failed to subscribe to events: %w", err)
 	}
 
 	go func() {
@@ -70,6 +71,8 @@ func (s *Service) SubscribeToBbnEvents(ctx context.Context) {
 			}
 		}
 	}()
+
+	return nil
 }
 
 // Resubscribe to missed BTC notifications


### PR DESCRIPTION
We need this for several reasons:

1. it's always best to pass error to caller so it can properly handle an error (either retry or stop the program in case of `main.go`)
2. tests simplification: instead of unexpected log.Fatal() we will call testify `NoError` function to check for an error