### PR TITLE
chore: reduce noise in lnd logs

### DIFF
--- a/config/config-local.yml
+++ b/config/config-local.yml
@@ -15,7 +15,7 @@ btc:
   maxretrytimes: 5
   retryinterval: 500ms
   netparams: signet  
-  #enablelndlogs: true
+  lndloglevel: error
 bbn:
   rpc-addr: https://rpc-dapp.devnet.babylonlabs.io:443
   timeout: 30s

--- a/internal/clients/btcclient/notifier.go
+++ b/internal/clients/btcclient/notifier.go
@@ -44,15 +44,18 @@ func NewBTCNotifier(
 
 	// Setup logging for chainntnfs. This enables logging and adds "NTFN" prefix
 	// to all logs coming from the chain notifier package.
-	if cfg.EnableLndLogs {
-		// by default, lnd logs are disabled
-		// TODO: proper solution is to make lnd logger compatible with zerolog and set
-		// the service level log level which will control all logging
-		backend := btclog.NewBackend(os.Stdout)
-		logger := backend.Logger("NTFN")
-		logger.SetLevel(btclog.LevelDebug)
-		chainntnfs.UseLogger(logger)
+	// TODO: proper solution is to make lnd logger compatible with zerolog and set
+	// the service level log level which will control all logging
+	backend := btclog.NewBackend(os.Stdout)
+	logger := backend.Logger("NTFN")
+
+	// Parse log level from config, default to "off" if not specified
+	level, ok := btclog.LevelFromString(cfg.LndLogLevel)
+	if !ok {
+		level = btclog.LevelOff
 	}
+	logger.SetLevel(level)
+	chainntnfs.UseLogger(logger)
 
 	bitcoindConn, err := chain.NewBitcoindConn(bitcoindCfg)
 	if err != nil {

--- a/internal/config/btc.go
+++ b/internal/config/btc.go
@@ -21,7 +21,7 @@ type BTCConfig struct {
 	MaxRetryTimes           uint          `mapstructure:"maxretrytimes"`
 	RetryInterval           time.Duration `mapstructure:"retryinterval"`
 	NetParams               string        `mapstructure:"netparams"`
-	EnableLndLogs           bool          `mapstructure:"enablelndlogs"`
+	LndLogLevel             string        `mapstructure:"lndloglevel"` // trace, debug, info, warn, error, critical, off
 }
 
 func (cfg *BTCConfig) ToConnConfig() (*rpcclient.ConnConfig, error) {


### PR DESCRIPTION
Ideal solution is to have a custom log interface b/w btclog (used by lnd) and zerolog and have a service level log level setting

For now i made a log level specific to btclogger (used by lnd) in the btc config 

this pr is not tested 🙈 