### PR TITLE
Remove Service WaitGroup

### DIFF
--- a/internal/services/service.go
+++ b/internal/services/service.go
@@ -2,8 +2,6 @@ package services
 
 import (
 	"context"
-	"sync"
-
 	"fmt"
 	"github.com/babylonlabs-io/babylon-staking-indexer/consumer"
 	"github.com/babylonlabs-io/babylon-staking-indexer/internal/clients/bbnclient"
@@ -13,7 +11,6 @@ import (
 )
 
 type Service struct {
-	wg   sync.WaitGroup
 	quit chan struct{}
 
 	cfg               *config.Config

--- a/internal/services/watch_btc_events.go
+++ b/internal/services/watch_btc_events.go
@@ -63,7 +63,6 @@ func (s *Service) watchForSpendUnbondingTx(
 	spendEvent *notifier.SpendEvent,
 	delegation *model.BTCDelegationDetails,
 ) {
-	defer s.wg.Done()
 	quitCtx, cancel := s.quitContext()
 	defer cancel()
 
@@ -103,7 +102,6 @@ func (s *Service) watchForSpendSlashingChange(
 	delegation *model.BTCDelegationDetails,
 	subState types.DelegationSubState,
 ) {
-	defer s.wg.Done()
 	quitCtx, cancel := s.quitContext()
 	defer cancel()
 


### PR DESCRIPTION
There are only `.Done()` calls without `.Add(...)` and `.Wait()`