### PR TITLE
Concurrency in processBlocksSequentially

### DIFF
--- a/internal/services/bootstrap.go
+++ b/internal/services/bootstrap.go
@@ -119,6 +119,7 @@ func (s *Service) FillStakerAddr(ctx context.Context, numWorkers int, dryRun boo
 // Returns an error if it fails to get block results or process events.
 func (s *Service) processBlocksSequentially(ctx context.Context) error {
 	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil) // if context already cancelled with error, nil won't override it
 
 	lastProcessedHeight, dbErr := s.db.GetLastProcessedBbnHeight(ctx)
 	if dbErr != nil {

--- a/internal/services/service.go
+++ b/internal/services/service.go
@@ -14,14 +14,13 @@ import (
 type Service struct {
 	quit chan struct{}
 
-	cfg               *config.Config
-	db                db.DbInterface
-	btc               btcclient.BtcInterface
-	btcNotifier       BtcNotifier
-	bbn               bbnclient.BbnInterface
-	queueManager      consumer.EventConsumer
-	bbnEventProcessor chan BbnEvent
-	latestHeightChan  chan int64
+	cfg              *config.Config
+	db               db.DbInterface
+	btc              btcclient.BtcInterface
+	btcNotifier      BtcNotifier
+	bbn              bbnclient.BbnInterface
+	queueManager     consumer.EventConsumer
+	latestHeightChan chan int64
 }
 
 func NewService(
@@ -32,20 +31,18 @@ func NewService(
 	bbn bbnclient.BbnInterface,
 	consumer consumer.EventConsumer,
 ) *Service {
-	eventProcessor := make(chan BbnEvent, eventProcessorSize)
 	latestHeightChan := make(chan int64)
 	// add retry wrapper to the btc notifier
 	btcNotifier = newBtcNotifierWithRetries(btcNotifier)
 	return &Service{
-		quit:              make(chan struct{}),
-		cfg:               cfg,
-		db:                db,
-		btc:               btc,
-		btcNotifier:       btcNotifier,
-		bbn:               bbn,
-		queueManager:      consumer,
-		bbnEventProcessor: eventProcessor,
-		latestHeightChan:  latestHeightChan,
+		quit:             make(chan struct{}),
+		cfg:              cfg,
+		db:               db,
+		btc:              btc,
+		btcNotifier:      btcNotifier,
+		bbn:              bbn,
+		queueManager:     consumer,
+		latestHeightChan: latestHeightChan,
 	}
 }
 


### PR DESCRIPTION
Issue #162

The purpose of this PR is to remove tight coupling between fetching events and processing them. 
Once they are independent (i.e. run concurrently) we will be able to change parallelism of events processing.

One thing to keep in mind that old log message might not be true anymore.
For example "Processed blocks up to height %d" means that this block was actually fetched, but it's going to be processed in future. I'm not sure does it make sense to keep existing logs or it would be better to change them.