### PR TITLE
Refactor: Use types.EventBTCDelegationUnbondedEarly Instead of bbnTypes.EventBTCDelgationUnbondedEarly

### DIFF
--- a/internal/services/delegation.go
+++ b/internal/services/delegation.go
@@ -252,8 +252,8 @@ func (s *Service) processBTCDelegationInclusionProofReceivedEvent(
 func (s *Service) processBTCDelegationUnbondedEarlyEvent(
 	ctx context.Context, event abcitypes.Event, bbnBlockHeight int64,
 ) error {
-	unbondedEarlyEvent, err := parseEvent[*bbntypes.EventBTCDelgationUnbondedEarly](
-		types.EventBTCDelgationUnbondedEarly,
+	unbondedEarlyEvent, err := parseEvent[*bbntypes.EventBTCDelegationUnbondedEarly](
+		types.EventBTCDelegationUnbondedEarly,
 		event,
 	)
 	if err != nil {
@@ -311,7 +311,7 @@ func (s *Service) processBTCDelegationUnbondedEarlyEvent(
 		Uint32("unbonding_time", delegation.UnbondingTime).
 		Uint32("unbonding_expire_height", unbondingExpireHeight).
 		Stringer("sub_state", subState).
-		Stringer("event_type", types.EventBTCDelgationUnbondedEarly).
+		Stringer("event_type", types.EventBTCDelegationUnbondedEarly).
 		Msg("updating delegation state")
 
 	// Update delegation state
@@ -324,7 +324,7 @@ func (s *Service) processBTCDelegationUnbondedEarlyEvent(
 		db.WithBbnHeight(bbnBlockHeight),
 		db.WithUnbondingBTCTimestamp(unbondingBtcTimestamp),
 		db.WithUnbondingStartHeight(unbondingStartHeight),
-		db.WithBbnEventType(types.EventBTCDelgationUnbondedEarly),
+		db.WithBbnEventType(types.EventBTCDelegationUnbondedEarly),
 	); err != nil {
 		if db.IsNotFoundError(err) {
 			// maybe the btc notifier has already identified the unbonding tx and updated the state


### PR DESCRIPTION


**Description:**  
This pull request updates the code to consistently use `types.EventBTCDelegationUnbondedEarly` instead of `bbnTypes.EventBTCDelgationUnbondedEarly` in the `processBTCDelegationUnbondedEarlyEvent` function. 