### PR TITLE
Revert "Add default case warning (#238)" 

### DIFF
--- a/internal/services/events.go
+++ b/internal/services/events.go
@@ -106,8 +106,6 @@ func (s *Service) doProcessEvent(
 	case types.EventConsumerRegistered:
 		log.Debug().Msg("Processing consumer registered event")
 		err = s.processEventConsumerRegisteredEvent(ctx, bbnEvent)
-	default:
-		log.Warn().Str("type", bbnEvent.Type).Msg("Unknown event type")
 	}
 
 	duration := time.Since(startTime)


### PR DESCRIPTION
Revert "Add default case warning (#238)" as it might lead to lot of noise from event that we don't care
