### PR TITLE
Replace quiteContext() with context.WithCancel(...)

### DIFF
--- a/internal/services/service.go
+++ b/internal/services/service.go
@@ -73,14 +73,3 @@ func (s *Service) StartIndexerSync(ctx context.Context) error {
 	// Keep processing BBN blocks in the main thread
 	return s.StartBbnBlockProcessor(ctx)
 }
-
-func (s *Service) quitContext() (context.Context, func()) {
-	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		defer cancel()
-
-		<-ctx.Done()
-	}()
-
-	return ctx, cancel
-}

--- a/internal/services/watch_btc_events.go
+++ b/internal/services/watch_btc_events.go
@@ -24,7 +24,7 @@ import (
 )
 
 func (s *Service) watchForSpendStakingTx(ctx context.Context, spendEvent *notifier.SpendEvent, stakingTxHashHex string) {
-	quitCtx, cancel := s.quitContext()
+	quitCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	log := log.Ctx(ctx)
@@ -59,7 +59,7 @@ func (s *Service) watchForSpendUnbondingTx(
 	spendEvent *notifier.SpendEvent,
 	delegation *model.BTCDelegationDetails,
 ) {
-	quitCtx, cancel := s.quitContext()
+	quitCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	log := log.Ctx(ctx)
@@ -96,7 +96,7 @@ func (s *Service) watchForSpendSlashingChange(
 	delegation *model.BTCDelegationDetails,
 	subState types.DelegationSubState,
 ) {
-	quitCtx, cancel := s.quitContext()
+	quitCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	log := log.Ctx(ctx)


### PR DESCRIPTION
Method `quitContext()` doesn't do anything. Replaced it with `context.WithCancel(...)` calls