### PR TITLE
fix: should populate bsnId for babylon FPs

### DIFF
--- a/internal/db/interface.go
+++ b/internal/db/interface.go
@@ -112,6 +112,24 @@ type DbInterface interface {
 		opts ...UpdateOption,
 	) error
 	/**
+	 * UpdateFinalityProviderBsnId updates the finality provider BSN ID.
+	 * @param ctx The context
+	 * @param btcPk The BTC public key
+	 * @param newBsnId The new BSN ID
+	 * @return An error if the operation failed
+	 */
+	UpdateFinalityProviderBsnId(
+		ctx context.Context, btcPk string, newBsnId string,
+	) error
+	/**
+	 * GetAllFinalityProviders retrieves all finality providers from the database.
+	 * @param ctx The context
+	 * @return The finality providers or an error
+	 */
+	GetAllFinalityProviders(ctx context.Context) (
+		[]*model.FinalityProviderDetails, error,
+	)
+	/**
 	 * SaveBTCDelegationUnbondingCovenantSignature saves a BTC delegation
 	 * unbonding covenant signature to the database.
 	 * @param ctx The context

--- a/internal/db/metrics.go
+++ b/internal/db/metrics.go
@@ -198,6 +198,25 @@ func (d *DbWithMetrics) GetDelegationsWithEmptyStakerAddress(ctx context.Context
 	return d.db.GetDelegationsWithEmptyStakerAddress(ctx)
 }
 
+func (d *DbWithMetrics) UpdateFinalityProviderBsnId(
+	ctx context.Context, btcPk, newBsnId string,
+) error {
+	return d.run("UpdateFinalityProviderBsnId", func() error {
+		return d.db.UpdateFinalityProviderBsnId(ctx, btcPk, newBsnId)
+	})
+}
+
+func (d *DbWithMetrics) GetAllFinalityProviders(
+	ctx context.Context,
+) (result []*model.FinalityProviderDetails, err error) {
+	//nolint:errcheck
+	d.run("GetAllFinalityProviders", func() error {
+		result, err = d.db.GetAllFinalityProviders(ctx)
+		return err
+	})
+	return
+}
+
 // run is private method that executes passed lambda function and send metrics data with spent time, method name
 // and an error if any. It returns the error from the lambda function for convenience
 func (d *DbWithMetrics) run(method string, f func() error) error {

--- a/internal/services/service.go
+++ b/internal/services/service.go
@@ -64,6 +64,11 @@ func (s *Service) StartIndexerSync(ctx context.Context) error {
 	s.fetchAndSaveNetworkInfo(ctx)
 	// Sync global parameters
 	s.SyncGlobalParams(ctx)
+	// Update finality providers with missing BSN IDs
+	// TODO: Remove this method in the future versions.
+	if _, err := s.UpdateBabylonFinalityProviderBsnId(ctx); err != nil {
+		return fmt.Errorf("failed to update babylon finality provider BSN IDs: %w", err)
+	}
 	// Resubscribe to missed BTC notifications
 	s.ResubscribeToMissedBtcNotifications(ctx)
 	// Start the expiry checker


### PR DESCRIPTION
Populate bsnId for babylon FPs if it's not present