### PR TITLE
feat: fp allowlist service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/babylonlabs-io/babylon-staking-indexer
 
-go 1.24.3
+go 1.24
 
 require (
 	cosmossdk.io/math v1.5.3
@@ -355,7 +355,7 @@ require (
 	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 replace (

--- a/internal/db/bsn.go
+++ b/internal/db/bsn.go
@@ -3,9 +3,13 @@ package db
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/babylonlabs-io/babylon-staking-indexer/internal/db/model"
+	"github.com/rs/zerolog/log"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 func (db *Database) SaveBSN(ctx context.Context, bsn *model.BSN) error {
@@ -47,4 +51,67 @@ func (db *Database) GetBSNByID(ctx context.Context, id string) (*model.BSN, erro
 	}
 
 	return &bsn, nil
+}
+
+// GetBSNByAddress retrieves a BSN by its finality contract address
+func (db *Database) GetBSNByAddress(ctx context.Context, address string) (*model.BSN, error) {
+	filter := bson.M{"rollup_metadata.finality_contract_address": address}
+	res := db.collection(model.BSNCollection).FindOne(ctx, filter)
+
+	var bsn model.BSN
+	err := res.Decode(&bsn)
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, &NotFoundError{
+				Key:     address,
+				Message: "bsn not found by address",
+			}
+		}
+		return nil, err
+	}
+
+	return &bsn, nil
+}
+
+// UpdateBSNAllowlist updates the BSN allowlist based on an allowlist event
+func (db *Database) UpdateBSNAllowlist(ctx context.Context, address string, pubkeys []string, eventType string) error {
+	log := log.Ctx(ctx)
+	bsn, err := db.GetBSNByAddress(ctx, address)
+	if err != nil {
+		log.Warn().Err(err).
+			Str("address", address).
+			Msg("BSN not found for allowlist update, skipping")
+		return nil
+	}
+
+	// Apply the allowlist update using the BSN model helper
+	bsn.UpdateAllowlistFromEvent(pubkeys, eventType)
+
+	filter := bson.M{"rollup_metadata.finality_contract_address": address}
+	update := bson.M{
+		"$set": bson.M{
+			"rollup_metadata.allowlist": bsn.RollupMetadata.Allowlist,
+		},
+	}
+
+	result, err := db.collection(model.BSNCollection).UpdateOne(ctx, filter, update, options.Update().SetUpsert(false))
+	if err != nil {
+		return fmt.Errorf("failed to update BSN allowlist: %w", err)
+	}
+
+	if result.MatchedCount == 0 {
+		log.Warn().
+			Str("address", address).
+			Msg("No BSN found to update allowlist for")
+		return nil
+	}
+
+	log.Info().
+		Str("address", address).
+		Str("event_type", eventType).
+		Interface("pubkeys", pubkeys).
+		Int("allowlist_size", len(bsn.RollupMetadata.Allowlist)).
+		Msg("BSN allowlist updated successfully")
+
+	return nil
 }

--- a/internal/db/finality_provider_allowlist.go
+++ b/internal/db/finality_provider_allowlist.go
@@ -1,0 +1,52 @@
+package db
+
+import (
+	"context"
+	"strings"
+
+	"github.com/babylonlabs-io/babylon-staking-indexer/internal/db/model"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// SetFPAllowlisted sets is_allowlisted for a subset of FPs in a BSN
+func (db *Database) SetFPAllowlisted(ctx context.Context, bsnID string, btcPks []string, value bool) error {
+	if len(btcPks) == 0 {
+		return nil
+	}
+
+	// normalize and dedup
+	set := make(map[string]struct{}, len(btcPks))
+	for _, pk := range btcPks {
+		l := strings.ToLower(pk)
+		set[l] = struct{}{}
+	}
+	lower := make([]string, 0, len(set))
+	for k := range set {
+		lower = append(lower, k)
+	}
+
+	filter := bson.M{"bsn_id": bsnID, "_id": bson.M{"$in": lower}}
+	update := bson.M{"$set": bson.M{"is_allowlisted": value}}
+	opts := options.Update().SetCollation(&options.Collation{Locale: "en", Strength: 2})
+
+	_, err := db.collection(model.FinalityProviderDetailsCollection).UpdateMany(ctx, filter, update, opts)
+	return err
+}
+
+// RecomputeFPAllowlistedForBSN sets all FPs in the BSN to false, then sets true for those in allowlist
+func (db *Database) RecomputeFPAllowlistedForBSN(ctx context.Context, bsnID string, allowlist []string) error {
+	// set all to false
+	filterAll := bson.M{"bsn_id": bsnID}
+	updateAll := bson.M{"$set": bson.M{"is_allowlisted": false}}
+	_, err := db.collection(model.FinalityProviderDetailsCollection).UpdateMany(ctx, filterAll, updateAll)
+	if err != nil {
+		return err
+	}
+
+	if len(allowlist) == 0 {
+		return nil
+	}
+
+	return db.SetFPAllowlisted(ctx, bsnID, allowlist, true)
+}

--- a/internal/db/interface.go
+++ b/internal/db/interface.go
@@ -218,4 +218,40 @@ type DbInterface interface {
 	UpdateDelegationStakerBabylonAddress(ctx context.Context, stakingTxHash, stakerBabylonAddress string) error
 	GetNetworkInfo(ctx context.Context) (*model.NetworkInfo, error)
 	UpsertNetworkInfo(ctx context.Context, networkInfo *model.NetworkInfo) error
+
+	/**
+	 * GetBSNByAddress retrieves a BSN by its finality contract address.
+	 * @param ctx The context
+	 * @param address The finality contract address
+	 * @return The BSN or an error
+	 */
+	GetBSNByAddress(ctx context.Context, address string) (*model.BSN, error)
+
+	/**
+	 * UpdateBSNAllowlist updates the BSN allowlist based on an allowlist event.
+	 * @param ctx The context
+	 * @param address The finality contract address
+	 * @param pubkeys The public keys to add/remove
+	 * @param eventType The type of event (types.ActionInstantiate, types.ActionAddToAllowlist, types.ActionRemoveFromAllowlist)
+	 * @return An error if the operation failed
+	 */
+	UpdateBSNAllowlist(ctx context.Context, address string, pubkeys []string, eventType string) error
+
+	/**
+	 * SetFPAllowlisted sets is_allowlisted to the provided value for the given btcPks within a BSN.
+	 * @param ctx The context
+	 * @param bsnID The BSN ID to scope the update
+	 * @param btcPks The list of FP BTC public keys (hex)
+	 * @param value The value to set for is_allowlisted
+	 */
+	SetFPAllowlisted(ctx context.Context, bsnID string, btcPks []string, value bool) error
+
+	/**
+	 * RecomputeFPAllowlistedForBSN recomputes is_allowlisted for all FPs in a BSN from the given allowlist.
+	 * It will set all to false, then set true for the provided allowlist.
+	 * @param ctx The context
+	 * @param bsnID The BSN ID
+	 * @param allowlist The full allowlist of BTC public keys (hex)
+	 */
+	RecomputeFPAllowlistedForBSN(ctx context.Context, bsnID string, allowlist []string) error
 }

--- a/internal/db/metrics.go
+++ b/internal/db/metrics.go
@@ -217,6 +217,32 @@ func (d *DbWithMetrics) GetAllFinalityProviders(
 	return
 }
 
+func (d *DbWithMetrics) GetBSNByAddress(ctx context.Context, address string) (result *model.BSN, err error) {
+	err = d.run("GetBSNByAddress", func() error {
+		result, err = d.db.GetBSNByAddress(ctx, address)
+		return err
+	})
+	return
+}
+
+func (d *DbWithMetrics) UpdateBSNAllowlist(ctx context.Context, address string, pubkeys []string, eventType string) error {
+	return d.run("UpdateBSNAllowlist", func() error {
+		return d.db.UpdateBSNAllowlist(ctx, address, pubkeys, eventType)
+	})
+}
+
+func (d *DbWithMetrics) SetFPAllowlisted(ctx context.Context, bsnID string, btcPks []string, value bool) error {
+	return d.run("SetFPAllowlisted", func() error {
+		return d.db.SetFPAllowlisted(ctx, bsnID, btcPks, value)
+	})
+}
+
+func (d *DbWithMetrics) RecomputeFPAllowlistedForBSN(ctx context.Context, bsnID string, allowlist []string) error {
+	return d.run("RecomputeFPAllowlistedForBSN", func() error {
+		return d.db.RecomputeFPAllowlistedForBSN(ctx, bsnID, allowlist)
+	})
+}
+
 // run is private method that executes passed lambda function and send metrics data with spent time, method name
 // and an error if any. It returns the error from the lambda function for convenience
 func (d *DbWithMetrics) run(method string, f func() error) error {

--- a/internal/db/model/bsn.go
+++ b/internal/db/model/bsn.go
@@ -1,6 +1,11 @@
 package model
 
-import btcstkconsumer "github.com/babylonlabs-io/babylon/v3/x/btcstkconsumer/types"
+import (
+	"strings"
+
+	"github.com/babylonlabs-io/babylon-staking-indexer/internal/types"
+	btcstkconsumer "github.com/babylonlabs-io/babylon/v3/x/btcstkconsumer/types"
+)
 
 type BSN struct {
 	ID             string         `bson:"_id"`
@@ -11,7 +16,8 @@ type BSN struct {
 }
 
 type ETHL2Metadata struct {
-	FinalityContractAddress string `bson:"finality_contract_address"`
+	FinalityContractAddress string   `bson:"finality_contract_address"`
+	Allowlist               []string `bson:"allowlist,omitempty"` // array of FP BTC pubkeys hex
 }
 
 func FromEventConsumerRegistered(event *btcstkconsumer.EventConsumerRegistered) *BSN {
@@ -29,4 +35,93 @@ func FromEventConsumerRegistered(event *btcstkconsumer.EventConsumerRegistered) 
 		Type:           event.ConsumerType.String(),
 		RollupMetadata: rollupMetadata,
 	}
+}
+
+// UpdateAllowlistFromEvent updates the allowlist based on an allowlist event
+func (b *BSN) UpdateAllowlistFromEvent(pubkeys []string, eventType string) {
+	if b.RollupMetadata == nil {
+		b.RollupMetadata = &ETHL2Metadata{}
+	}
+
+	norm := normalizePubkeys(pubkeys)
+
+	switch eventType {
+	case types.ActionInstantiate:
+		if len(norm) > 0 {
+			b.RollupMetadata.Allowlist = norm
+		}
+	case types.ActionAddToAllowlist:
+		if len(norm) > 0 {
+			b.mergeAllowlist(norm)
+		}
+	case types.ActionRemoveFromAllowlist:
+		b.removeFromAllowlist(norm)
+	}
+}
+
+func normalizePubkeys(pubkeys []string) []string {
+	seen := make(map[string]struct{}, len(pubkeys))
+	out := make([]string, 0, len(pubkeys))
+	for _, pk := range pubkeys {
+		l := strings.ToLower(pk)
+		if l == "" {
+			continue
+		}
+		if _, ok := seen[l]; ok {
+			continue
+		}
+		seen[l] = struct{}{}
+		out = append(out, l)
+	}
+	return out
+}
+
+// mergeAllowlist adds new pubkeys to the allowlist while avoiding duplicates
+func (b *BSN) mergeAllowlist(newPubkeys []string) {
+	if b.RollupMetadata == nil {
+		return
+	}
+
+	b.RollupMetadata.Allowlist = normalizePubkeys(b.RollupMetadata.Allowlist)
+	present := make(map[string]struct{}, len(b.RollupMetadata.Allowlist))
+	for _, pk := range b.RollupMetadata.Allowlist {
+		present[pk] = struct{}{}
+	}
+
+	for _, pk := range newPubkeys {
+		l := strings.ToLower(pk)
+		if _, ok := present[l]; !ok {
+			b.RollupMetadata.Allowlist = append(b.RollupMetadata.Allowlist, l)
+			present[l] = struct{}{}
+		}
+	}
+}
+
+// removeFromAllowlist removes specified pubkeys from the allowlist
+func (b *BSN) removeFromAllowlist(pubkeysToRemove []string) {
+	if b.RollupMetadata == nil {
+		return
+	}
+
+	b.RollupMetadata.Allowlist = normalizePubkeys(b.RollupMetadata.Allowlist)
+	toRemove := make(map[string]struct{}, len(pubkeysToRemove))
+	for _, pk := range pubkeysToRemove {
+		toRemove[strings.ToLower(pk)] = struct{}{}
+	}
+
+	var filtered []string
+	for _, pk := range b.RollupMetadata.Allowlist {
+		if _, rm := toRemove[pk]; !rm {
+			filtered = append(filtered, pk)
+		}
+	}
+
+	b.RollupMetadata.Allowlist = filtered
+}
+
+// HasAllowlistForContract returns true if this BSN has an allowlist for the given contract address
+func (b *BSN) HasAllowlistForContract(address string) bool {
+	return b.RollupMetadata != nil &&
+		b.RollupMetadata.FinalityContractAddress == address &&
+		len(b.RollupMetadata.Allowlist) > 0
 }

--- a/internal/db/model/finality_provider.go
+++ b/internal/db/model/finality_provider.go
@@ -1,6 +1,10 @@
 package model
 
-import bbntypes "github.com/babylonlabs-io/babylon/v3/x/btcstaking/types"
+import (
+	"strings"
+
+	bbntypes "github.com/babylonlabs-io/babylon/v3/x/btcstaking/types"
+)
 
 type FinalityProviderDetails struct {
 	BtcPk          string      `bson:"_id"` // Primary key
@@ -9,6 +13,7 @@ type FinalityProviderDetails struct {
 	State          string      `bson:"state"`
 	Description    Description `bson:"description"`
 	BsnID          string      `bson:"bsn_id"`
+	IsAllowlisted  bool        `bson:"is_allowlisted"`
 }
 
 // Description represents the nested description field
@@ -24,7 +29,7 @@ func FromEventFinalityProviderCreated(
 	event *bbntypes.EventFinalityProviderCreated,
 ) *FinalityProviderDetails {
 	return &FinalityProviderDetails{
-		BtcPk:          event.BtcPkHex,
+		BtcPk:          strings.ToLower(event.BtcPkHex),
 		BabylonAddress: event.Addr,
 		Description: Description{
 			Moniker:         event.Moniker,
@@ -43,7 +48,7 @@ func FromEventFinalityProviderEdited(
 	event *bbntypes.EventFinalityProviderEdited,
 ) *FinalityProviderDetails {
 	return &FinalityProviderDetails{
-		BtcPk: event.BtcPkHex,
+		BtcPk: strings.ToLower(event.BtcPkHex),
 		Description: Description{
 			Moniker:         event.Moniker,
 			Identity:        event.Identity,

--- a/internal/db/model/setup.go
+++ b/internal/db/model/setup.go
@@ -29,7 +29,10 @@ type index struct {
 }
 
 var collections = map[string][]index{
-	FinalityProviderDetailsCollection: {{Indexes: map[string]int{}}},
+	FinalityProviderDetailsCollection: {
+		{Indexes: map[string]int{"bsn_id": 1}, Unique: false},
+		{Indexes: map[string]int{"bsn_id": 1, "_id": 1}, Unique: false}, // compound for FP allowlist updates
+	},
 	BTCDelegationDetailsCollection: {
 		{
 			Indexes: map[string]int{
@@ -47,7 +50,10 @@ var collections = map[string][]index{
 		{Indexes: map[string]int{"type": 1, "version": 1}, Unique: true},
 	},
 	LastProcessedHeightCollection: {{Indexes: map[string]int{}}},
-	NetworkInfoCollection:         {{Indexes: map[string]int{}}},
+	BSNCollection: {
+		{Indexes: map[string]int{"rollup_metadata.finality_contract_address": 1}, Unique: false},
+	},
+	NetworkInfoCollection: {{Indexes: map[string]int{}}},
 }
 
 func Setup(ctx context.Context, cfg *config.DbConfig) error {

--- a/internal/services/events.go
+++ b/internal/services/events.go
@@ -106,9 +106,15 @@ func (s *Service) doProcessEvent(
 	case types.EventConsumerRegistered:
 		log.Debug().Msg("Processing consumer registered event")
 		err = s.processEventConsumerRegisteredEvent(ctx, bbnEvent)
-	case types.EventWasmInstantiate, types.EventWasm, types.EventWasmAddToAllowlist, types.EventWasmRemoveFromAllowlist:
-		log.Debug().Msg("Processing allowlist event")
-		err = s.processAllowlistEvent(ctx, bbnEvent, blockHeight)
+	case types.EventWasm:
+		log.Debug().Msg("Processing wasm instantiate event")
+		err = s.processAllowlistInstantiateEvent(ctx, bbnEvent, blockHeight)
+	case types.EventWasmAddToAllowlist:
+		log.Debug().Msg("Processing add to allowlist event")
+		err = s.processAddToAllowlistEvent(ctx, bbnEvent, blockHeight)
+	case types.EventWasmRemoveFromAllowlist:
+		log.Debug().Msg("Processing remove from allowlist event")
+		err = s.processRemoveFromAllowlistEvent(ctx, bbnEvent, blockHeight)
 	}
 
 	duration := time.Since(startTime)
@@ -383,33 +389,4 @@ func sanitizeEvent(event abcitypes.Event) abcitypes.Event {
 		Type:       event.Type,
 		Attributes: sanitizedAttrs,
 	}
-}
-
-// processAllowlistEvent is a bootstrap implementation that logs allowlist events
-// TODO: Implement full allowlist processing logic
-func (s *Service) processAllowlistEvent(ctx context.Context, event abcitypes.Event, blockHeight int64) error {
-	log := log.Ctx(ctx)
-
-	// Parse the allowlist event
-	allowlistEvent, err := types.ParseAllowlistEvent(event)
-	if err != nil {
-		log.Error().Err(err).
-			Str("event_type", event.Type).
-			Int64("block_height", blockHeight).
-			Msg("Failed to parse allowlist event")
-		return err
-	}
-
-	// Log the parsed event details
-	log.Info().
-		Str("event_type", string(allowlistEvent.EventType)).
-		Str("address", allowlistEvent.Address).
-		Str("action", allowlistEvent.Action).
-		Interface("allowlist", allowlistEvent.AllowList).
-		Interface("fp_pubkeys", allowlistEvent.FpPubkeys).
-		Str("msg_index", allowlistEvent.MsgIndex).
-		Int64("block_height", blockHeight).
-		Msg("Bootstrap: Allowlist event processed (logged only)")
-
-	return nil
 }

--- a/internal/services/events.go
+++ b/internal/services/events.go
@@ -106,6 +106,9 @@ func (s *Service) doProcessEvent(
 	case types.EventConsumerRegistered:
 		log.Debug().Msg("Processing consumer registered event")
 		err = s.processEventConsumerRegisteredEvent(ctx, bbnEvent)
+	case types.EventWasmInstantiate, types.EventWasm, types.EventWasmAddToAllowlist, types.EventWasmRemoveFromAllowlist:
+		log.Debug().Msg("Processing allowlist event")
+		err = s.processAllowlistEvent(ctx, bbnEvent, blockHeight)
 	}
 
 	duration := time.Since(startTime)
@@ -380,4 +383,33 @@ func sanitizeEvent(event abcitypes.Event) abcitypes.Event {
 		Type:       event.Type,
 		Attributes: sanitizedAttrs,
 	}
+}
+
+// processAllowlistEvent is a bootstrap implementation that logs allowlist events
+// TODO: Implement full allowlist processing logic
+func (s *Service) processAllowlistEvent(ctx context.Context, event abcitypes.Event, blockHeight int64) error {
+	log := log.Ctx(ctx)
+
+	// Parse the allowlist event
+	allowlistEvent, err := types.ParseAllowlistEvent(event)
+	if err != nil {
+		log.Error().Err(err).
+			Str("event_type", event.Type).
+			Int64("block_height", blockHeight).
+			Msg("Failed to parse allowlist event")
+		return err
+	}
+
+	// Log the parsed event details
+	log.Info().
+		Str("event_type", string(allowlistEvent.EventType)).
+		Str("address", allowlistEvent.Address).
+		Str("action", allowlistEvent.Action).
+		Interface("allowlist", allowlistEvent.AllowList).
+		Interface("fp_pubkeys", allowlistEvent.FpPubkeys).
+		Str("msg_index", allowlistEvent.MsgIndex).
+		Int64("block_height", blockHeight).
+		Msg("Bootstrap: Allowlist event processed (logged only)")
+
+	return nil
 }

--- a/internal/services/events.go
+++ b/internal/services/events.go
@@ -107,7 +107,7 @@ func (s *Service) doProcessEvent(
 		log.Debug().Msg("Processing consumer registered event")
 		err = s.processEventConsumerRegisteredEvent(ctx, bbnEvent)
 	case types.EventWasm:
-		log.Debug().Msg("Processing wasm instantiate event")
+		log.Debug().Msg("Processing wasm allowlist event")
 		err = s.processAllowlistInstantiateEvent(ctx, bbnEvent, blockHeight)
 	case types.EventWasmAddToAllowlist:
 		log.Debug().Msg("Processing add to allowlist event")

--- a/internal/services/main_test.go
+++ b/internal/services/main_test.go
@@ -136,6 +136,7 @@ func resetDatabase(t *testing.T) {
 		model.TimeLockCollection,
 		model.GlobalParamsCollection,
 		model.LastProcessedHeightCollection,
+		model.BSNCollection,
 	}
 
 	for _, collection := range collections {

--- a/internal/services/rollup_fp_allowlist.go
+++ b/internal/services/rollup_fp_allowlist.go
@@ -1,0 +1,91 @@
+package services
+
+import (
+	"context"
+
+	"github.com/babylonlabs-io/babylon-staking-indexer/internal/types"
+	abcitypes "github.com/cometbft/cometbft/abci/types"
+	"github.com/rs/zerolog/log"
+)
+
+// processAllowlistInstantiateEvent processes contract instantiation events
+// TODO: Implement database persistence and business logic for instantiate events
+func (s *Service) processAllowlistInstantiateEvent(ctx context.Context, event abcitypes.Event, blockHeight int64) error {
+	log := log.Ctx(ctx)
+
+	// Parse the allowlist event
+	allowlistEvent, err := types.ParseAllowlistEvent(event)
+	if err != nil {
+		log.Error().Err(err).
+			Str("event_type", event.Type).
+			Int64("block_height", blockHeight).
+			Msg("Failed to parse allowlist instantiate event")
+		return err
+	}
+
+	// Log the parsed instantiate event details
+	log.Debug().
+		Str("event_type", string(allowlistEvent.EventType)).
+		Str("address", allowlistEvent.Address).
+		Str("action", allowlistEvent.Action).
+		Interface("allowlist", allowlistEvent.AllowList).
+		Str("msg_index", allowlistEvent.MsgIndex).
+		Int64("block_height", blockHeight).
+		Msg("Bootstrap: Allowlist instantiate event processed (logged only)")
+
+	return nil
+}
+
+// processAddToAllowlistEvent processes specialized add to allowlist events
+// TODO: Implement database persistence and business logic for add to allowlist events
+func (s *Service) processAddToAllowlistEvent(ctx context.Context, event abcitypes.Event, blockHeight int64) error {
+	log := log.Ctx(ctx)
+
+	// Parse the allowlist event
+	allowlistEvent, err := types.ParseAllowlistEvent(event)
+	if err != nil {
+		log.Error().Err(err).
+			Str("event_type", event.Type).
+			Int64("block_height", blockHeight).
+			Msg("Failed to parse add to allowlist event")
+		return err
+	}
+
+	// Log the parsed add to allowlist event details
+	log.Debug().
+		Str("event_type", string(allowlistEvent.EventType)).
+		Str("address", allowlistEvent.Address).
+		Interface("fp_pubkeys", allowlistEvent.FpPubkeys).
+		Str("msg_index", allowlistEvent.MsgIndex).
+		Int64("block_height", blockHeight).
+		Msg("Bootstrap: Add to allowlist event processed (logged only)")
+
+	return nil
+}
+
+// processRemoveFromAllowlistEvent processes specialized remove from allowlist events
+// TODO: Implement database persistence and business logic for remove from allowlist events
+func (s *Service) processRemoveFromAllowlistEvent(ctx context.Context, event abcitypes.Event, blockHeight int64) error {
+	log := log.Ctx(ctx)
+
+	// Parse the allowlist event
+	allowlistEvent, err := types.ParseAllowlistEvent(event)
+	if err != nil {
+		log.Error().Err(err).
+			Str("event_type", event.Type).
+			Int64("block_height", blockHeight).
+			Msg("Failed to parse remove from allowlist event")
+		return err
+	}
+
+	// Log the parsed remove from allowlist event details
+	log.Debug().
+		Str("event_type", string(allowlistEvent.EventType)).
+		Str("address", allowlistEvent.Address).
+		Interface("fp_pubkeys", allowlistEvent.FpPubkeys).
+		Str("msg_index", allowlistEvent.MsgIndex).
+		Int64("block_height", blockHeight).
+		Msg("Bootstrap: Remove from allowlist event processed (logged only)")
+
+	return nil
+}

--- a/internal/services/rollup_fp_allowlist.go
+++ b/internal/services/rollup_fp_allowlist.go
@@ -2,15 +2,32 @@ package services
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
+	"github.com/babylonlabs-io/babylon-staking-indexer/internal/db/model"
 	"github.com/babylonlabs-io/babylon-staking-indexer/internal/types"
 	abcitypes "github.com/cometbft/cometbft/abci/types"
 	"github.com/rs/zerolog/log"
 )
 
 // processAllowlistInstantiateEvent processes contract instantiation events
-// TODO: Implement database persistence and business logic for instantiate events
 func (s *Service) processAllowlistInstantiateEvent(ctx context.Context, event abcitypes.Event, blockHeight int64) error {
+	return s.processAllowlistEvent(ctx, event, blockHeight, types.ActionInstantiate, "Processing allowlist instantiate event")
+}
+
+// processAddToAllowlistEvent processes specialized add to allowlist events
+func (s *Service) processAddToAllowlistEvent(ctx context.Context, event abcitypes.Event, blockHeight int64) error {
+	return s.processAllowlistEvent(ctx, event, blockHeight, types.ActionAddToAllowlist, "Processing add to allowlist event")
+}
+
+// processRemoveFromAllowlistEvent processes specialized remove from allowlist events
+func (s *Service) processRemoveFromAllowlistEvent(ctx context.Context, event abcitypes.Event, blockHeight int64) error {
+	return s.processAllowlistEvent(ctx, event, blockHeight, types.ActionRemoveFromAllowlist, "Processing remove from allowlist event")
+}
+
+// processAllowlistEvent handles the common allowlist processing logic
+func (s *Service) processAllowlistEvent(ctx context.Context, event abcitypes.Event, blockHeight int64, eventType string, logMsg string) error {
 	log := log.Ctx(ctx)
 
 	// Parse the allowlist event
@@ -19,73 +36,174 @@ func (s *Service) processAllowlistInstantiateEvent(ctx context.Context, event ab
 		log.Error().Err(err).
 			Str("event_type", event.Type).
 			Int64("block_height", blockHeight).
-			Msg("Failed to parse allowlist instantiate event")
+			Msgf("Failed to parse allowlist event: %s", eventType)
 		return err
 	}
 
-	// Log the parsed instantiate event details
+	// Log event details
 	log.Debug().
 		Str("event_type", string(allowlistEvent.EventType)).
 		Str("address", allowlistEvent.Address).
 		Str("action", allowlistEvent.Action).
+		Interface("fp_pubkeys", allowlistEvent.FpPubkeys).
 		Interface("allowlist", allowlistEvent.AllowList).
 		Str("msg_index", allowlistEvent.MsgIndex).
 		Int64("block_height", blockHeight).
-		Msg("Bootstrap: Allowlist instantiate event processed (logged only)")
+		Msg(logMsg)
+
+	// Check if we have a BSN registered for this contract address
+	bsn, err := s.db.GetBSNByAddress(ctx, allowlistEvent.Address)
+	if err != nil {
+		log.Warn().Err(err).
+			Str("address", allowlistEvent.Address).
+			Msg("BSN not found for allowlist event, skipping")
+		return nil
+	}
+
+	// Get pubkeys based on event type
+	var pubkeys []string
+	switch eventType {
+	case types.ActionInstantiate:
+		pubkeys = allowlistEvent.GetPubkeys()
+	case types.ActionAddToAllowlist, types.ActionRemoveFromAllowlist:
+		pubkeys = allowlistEvent.FpPubkeys
+	default:
+		log.Warn().
+			Str("event_type", string(allowlistEvent.EventType)).
+			Str("action", allowlistEvent.Action).
+			Msgf("Unknown allowlist event type: %s", eventType)
+		return nil
+	}
+
+	if len(pubkeys) == 0 {
+		log.Debug().
+			Str("event_type", string(allowlistEvent.EventType)).
+			Str("action", allowlistEvent.Action).
+			Msg("No pubkeys in allowlist event, skipping")
+		return nil
+	}
+
+	// Compute changes
+	added, removed := s.computeAllowlistChanges(bsn, pubkeys, eventType)
+
+	// Persist BSN allowlist
+	if err := s.db.UpdateBSNAllowlist(ctx, allowlistEvent.Address, pubkeys, eventType); err != nil {
+		log.Error().Err(err).
+			Str("address", allowlistEvent.Address).
+			Str("event_type", eventType).
+			Msg("Failed to update BSN allowlist")
+		return fmt.Errorf("failed to update BSN allowlist: %w", err)
+	}
+
+	// Update FP allowlist flags
+	if err := s.updateFPAllowlistFlags(ctx, bsn.ID, added, removed); err != nil {
+		return err
+	}
+
+	log.Info().
+		Str("bsn_id", bsn.ID).
+		Str("bsn_name", bsn.Name).
+		Str("address", allowlistEvent.Address).
+		Str("event_type", eventType).
+		Interface("pubkeys", pubkeys).
+		Int("added", len(added)).
+		Int("removed", len(removed)).
+		Int64("block_height", blockHeight).
+		Msg("Successfully processed allowlist event")
 
 	return nil
 }
 
-// processAddToAllowlistEvent processes specialized add to allowlist events
-// TODO: Implement database persistence and business logic for add to allowlist events
-func (s *Service) processAddToAllowlistEvent(ctx context.Context, event abcitypes.Event, blockHeight int64) error {
-	log := log.Ctx(ctx)
-
-	// Parse the allowlist event
-	allowlistEvent, err := types.ParseAllowlistEvent(event)
-	if err != nil {
-		log.Error().Err(err).
-			Str("event_type", event.Type).
-			Int64("block_height", blockHeight).
-			Msg("Failed to parse add to allowlist event")
-		return err
+// computeAllowlistChanges calculates which pubkeys should be added or removed
+func (s *Service) computeAllowlistChanges(bsn *model.BSN, pubkeys []string, eventType string) ([]string, []string) {
+	// Build old allowlist set
+	oldSet := make(map[string]struct{})
+	if bsn.RollupMetadata != nil {
+		for _, k := range bsn.RollupMetadata.Allowlist {
+			oldSet[strings.ToLower(k)] = struct{}{}
+		}
 	}
 
-	// Log the parsed add to allowlist event details
-	log.Debug().
-		Str("event_type", string(allowlistEvent.EventType)).
-		Str("address", allowlistEvent.Address).
-		Interface("fp_pubkeys", allowlistEvent.FpPubkeys).
-		Str("msg_index", allowlistEvent.MsgIndex).
-		Int64("block_height", blockHeight).
-		Msg("Bootstrap: Add to allowlist event processed (logged only)")
+	// Normalize new pubkeys
+	normPub := normalizePubkeys(pubkeys)
+
+	switch eventType {
+	case types.ActionInstantiate:
+		// Full snapshot: diff new vs old
+		newSet := make(map[string]struct{}, len(normPub))
+		for _, k := range normPub {
+			newSet[k] = struct{}{}
+		}
+
+		added := make([]string, 0)
+		for k := range newSet {
+			if _, ok := oldSet[k]; !ok {
+				added = append(added, k)
+			}
+		}
+
+		removed := make([]string, 0)
+		for k := range oldSet {
+			if _, ok := newSet[k]; !ok {
+				removed = append(removed, k)
+			}
+		}
+		return added, removed
+
+	case types.ActionAddToAllowlist:
+		return normPub, nil
+
+	case types.ActionRemoveFromAllowlist:
+		return nil, normPub
+
+	default:
+		return nil, nil
+	}
+}
+
+// updateFPAllowlistFlags updates the allowlist flags for finality providers
+func (s *Service) updateFPAllowlistFlags(ctx context.Context, bsnID string, added, removed []string) error {
+	log := log.Ctx(ctx)
+
+	if len(added) > 0 {
+		if err := s.db.SetFPAllowlisted(ctx, bsnID, added, true); err != nil {
+			log.Error().Err(err).
+				Str("bsn_id", bsnID).
+				Interface("added", added).
+				Msg("Failed to set is_allowlisted=true for added pubkeys")
+			return err
+		}
+	}
+
+	if len(removed) > 0 {
+		if err := s.db.SetFPAllowlisted(ctx, bsnID, removed, false); err != nil {
+			log.Error().Err(err).
+				Str("bsn_id", bsnID).
+				Interface("removed", removed).
+				Msg("Failed to set is_allowlisted=false for removed pubkeys")
+			return err
+		}
+	}
 
 	return nil
 }
 
-// processRemoveFromAllowlistEvent processes specialized remove from allowlist events
-// TODO: Implement database persistence and business logic for remove from allowlist events
-func (s *Service) processRemoveFromAllowlistEvent(ctx context.Context, event abcitypes.Event, blockHeight int64) error {
-	log := log.Ctx(ctx)
+// normalizePubkeys normalizes and deduplicates pubkeys
+func normalizePubkeys(pubkeys []string) []string {
+	seen := make(map[string]struct{}, len(pubkeys))
+	result := make([]string, 0, len(pubkeys))
 
-	// Parse the allowlist event
-	allowlistEvent, err := types.ParseAllowlistEvent(event)
-	if err != nil {
-		log.Error().Err(err).
-			Str("event_type", event.Type).
-			Int64("block_height", blockHeight).
-			Msg("Failed to parse remove from allowlist event")
-		return err
+	for _, pk := range pubkeys {
+		l := strings.ToLower(pk)
+		if l == "" {
+			continue
+		}
+		if _, ok := seen[l]; ok {
+			continue
+		}
+		seen[l] = struct{}{}
+		result = append(result, l)
 	}
 
-	// Log the parsed remove from allowlist event details
-	log.Debug().
-		Str("event_type", string(allowlistEvent.EventType)).
-		Str("address", allowlistEvent.Address).
-		Interface("fp_pubkeys", allowlistEvent.FpPubkeys).
-		Str("msg_index", allowlistEvent.MsgIndex).
-		Int64("block_height", blockHeight).
-		Msg("Bootstrap: Remove from allowlist event processed (logged only)")
-
-	return nil
+	return result
 }

--- a/internal/services/rollup_fp_allowlist_test.go
+++ b/internal/services/rollup_fp_allowlist_test.go
@@ -1,0 +1,245 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/babylonlabs-io/babylon-staking-indexer/internal/db/model"
+	"github.com/babylonlabs-io/babylon-staking-indexer/internal/types"
+	abcitypes "github.com/cometbft/cometbft/abci/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComputeAllowlistChanges(t *testing.T) {
+	srv := &Service{}
+
+	t.Run("instantiate event - full snapshot", func(t *testing.T) {
+		bsn := &model.BSN{
+			RollupMetadata: &model.ETHL2Metadata{
+				Allowlist: []string{"old_pubkey1", "old_pubkey2"},
+			},
+		}
+		pubkeys := []string{"new_pubkey1", "old_pubkey1", "new_pubkey2"}
+
+		added, removed := srv.computeAllowlistChanges(bsn, pubkeys, types.ActionInstantiate)
+
+		assert.Equal(t, []string{"new_pubkey1", "new_pubkey2"}, added)
+		assert.Equal(t, []string{"old_pubkey2"}, removed)
+	})
+
+	t.Run("add to allowlist event", func(t *testing.T) {
+		bsn := &model.BSN{}
+		pubkeys := []string{"new_pubkey1", "new_pubkey2"}
+
+		added, removed := srv.computeAllowlistChanges(bsn, pubkeys, types.ActionAddToAllowlist)
+
+		assert.Equal(t, []string{"new_pubkey1", "new_pubkey2"}, added)
+		assert.Nil(t, removed)
+	})
+
+	t.Run("remove from allowlist event", func(t *testing.T) {
+		bsn := &model.BSN{}
+		pubkeys := []string{"remove_pubkey1", "remove_pubkey2"}
+
+		added, removed := srv.computeAllowlistChanges(bsn, pubkeys, types.ActionRemoveFromAllowlist)
+
+		assert.Nil(t, added)
+		assert.Equal(t, []string{"remove_pubkey1", "remove_pubkey2"}, removed)
+	})
+
+	t.Run("unknown event type", func(t *testing.T) {
+		bsn := &model.BSN{}
+		pubkeys := []string{"some_pubkey"}
+
+		added, removed := srv.computeAllowlistChanges(bsn, pubkeys, "unknown")
+
+		assert.Nil(t, added)
+		assert.Nil(t, removed)
+	})
+
+	t.Run("instantiate with empty old allowlist", func(t *testing.T) {
+		bsn := &model.BSN{
+			RollupMetadata: &model.ETHL2Metadata{},
+		}
+		pubkeys := []string{"new_pubkey1", "new_pubkey2"}
+
+		added, removed := srv.computeAllowlistChanges(bsn, pubkeys, types.ActionInstantiate)
+
+		assert.Equal(t, []string{"new_pubkey1", "new_pubkey2"}, added)
+		assert.Empty(t, removed) // Empty slice, not nil
+	})
+
+	t.Run("instantiate with no rollup metadata", func(t *testing.T) {
+		bsn := &model.BSN{}
+		pubkeys := []string{"new_pubkey1", "new_pubkey2"}
+
+		added, removed := srv.computeAllowlistChanges(bsn, pubkeys, types.ActionInstantiate)
+
+		assert.Equal(t, []string{"new_pubkey1", "new_pubkey2"}, added)
+		assert.Empty(t, removed) // Empty slice, not nil
+	})
+}
+
+func TestNormalizePubkeys(t *testing.T) {
+	t.Run("normalize and deduplicate pubkeys", func(t *testing.T) {
+		pubkeys := []string{"PUBKEY1", "pubkey2", "", "PUBKEY1", "pubkey3", "  pubkey4  "}
+
+		result := normalizePubkeys(pubkeys)
+
+		expected := []string{"pubkey1", "pubkey2", "pubkey3", "  pubkey4  "} // whitespace is preserved
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		pubkeys := []string{}
+
+		result := normalizePubkeys(pubkeys)
+
+		assert.Empty(t, result)
+	})
+
+	t.Run("only empty strings", func(t *testing.T) {
+		pubkeys := []string{"", "  ", ""}
+
+		result := normalizePubkeys(pubkeys)
+
+		expected := []string{"  "} // non-empty strings are kept
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("mixed case with duplicates", func(t *testing.T) {
+		pubkeys := []string{"ABC", "def", "ABC", "DEF", "ghi"}
+
+		result := normalizePubkeys(pubkeys)
+
+		expected := []string{"abc", "def", "ghi"}
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("whitespace handling", func(t *testing.T) {
+		pubkeys := []string{"  abc  ", "\tdef\t", " ghi ", "abc"}
+
+		result := normalizePubkeys(pubkeys)
+
+		expected := []string{"  abc  ", "\tdef\t", " ghi ", "abc"} // whitespace is preserved
+		assert.Equal(t, expected, result)
+	})
+}
+
+func TestParseAllowlistEventIntegration(t *testing.T) {
+	t.Run("instantiate event parsing", func(t *testing.T) {
+		event := abcitypes.Event{
+			Type: "wasm",
+			Attributes: []abcitypes.EventAttribute{
+				{Key: "_contract_address", Value: "test_address"},
+				{Key: "action", Value: "instantiate"},
+				{Key: "allow-list", Value: "pubkey1,pubkey2,pubkey3"},
+				{Key: "msg_index", Value: "0"},
+			},
+		}
+
+		allowlistEvent, err := types.ParseAllowlistEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, allowlistEvent)
+
+		assert.Equal(t, "test_address", allowlistEvent.Address)
+		assert.Equal(t, []string{"pubkey1", "pubkey2", "pubkey3"}, allowlistEvent.AllowList)
+		assert.True(t, allowlistEvent.IsInstantiateEvent())
+		assert.Equal(t, []string{"pubkey1", "pubkey2", "pubkey3"}, allowlistEvent.GetPubkeys())
+	})
+
+	t.Run("add to allowlist event parsing", func(t *testing.T) {
+		event := abcitypes.Event{
+			Type: "wasm-add_to_allowlist",
+			Attributes: []abcitypes.EventAttribute{
+				{Key: "_contract_address", Value: "test_address"},
+				{Key: "fp_pubkeys", Value: "new_pubkey1,new_pubkey2"},
+				{Key: "msg_index", Value: "0"},
+			},
+		}
+
+		allowlistEvent, err := types.ParseAllowlistEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, allowlistEvent)
+
+		assert.Equal(t, "test_address", allowlistEvent.Address)
+		assert.Equal(t, []string{"new_pubkey1", "new_pubkey2"}, allowlistEvent.FpPubkeys)
+		assert.True(t, allowlistEvent.IsAddEvent())
+		assert.Equal(t, []string{"new_pubkey1", "new_pubkey2"}, allowlistEvent.GetPubkeys())
+	})
+
+	t.Run("remove from allowlist event parsing", func(t *testing.T) {
+		event := abcitypes.Event{
+			Type: "wasm-remove_from_allowlist",
+			Attributes: []abcitypes.EventAttribute{
+				{Key: "_contract_address", Value: "test_address"},
+				{Key: "fp_pubkeys", Value: "remove_pubkey1,remove_pubkey2"},
+				{Key: "msg_index", Value: "0"},
+			},
+		}
+
+		allowlistEvent, err := types.ParseAllowlistEvent(event)
+		require.NoError(t, err)
+		require.NotNil(t, allowlistEvent)
+
+		assert.Equal(t, "test_address", allowlistEvent.Address)
+		assert.Equal(t, []string{"remove_pubkey1", "remove_pubkey2"}, allowlistEvent.FpPubkeys)
+		assert.True(t, allowlistEvent.IsRemoveEvent())
+		assert.Equal(t, []string{"remove_pubkey1", "remove_pubkey2"}, allowlistEvent.GetPubkeys())
+	})
+
+	t.Run("invalid event type", func(t *testing.T) {
+		event := abcitypes.Event{
+			Type: "invalid_event_type",
+			Attributes: []abcitypes.EventAttribute{
+				{Key: "_contract_address", Value: "test_address"},
+			},
+		}
+
+		allowlistEvent, err := types.ParseAllowlistEvent(event)
+		assert.Error(t, err)
+		assert.Nil(t, allowlistEvent)
+		assert.Equal(t, types.ErrNotAllowlistEvent, err)
+	})
+
+	t.Run("missing contract address", func(t *testing.T) {
+		event := abcitypes.Event{
+			Type: "wasm",
+			Attributes: []abcitypes.EventAttribute{
+				{Key: "action", Value: "instantiate"},
+				{Key: "allow-list", Value: "pubkey1"},
+			},
+		}
+
+		allowlistEvent, err := types.ParseAllowlistEvent(event)
+		assert.Error(t, err)
+		assert.Nil(t, allowlistEvent)
+		assert.Contains(t, err.Error(), "missing address")
+	})
+}
+
+func TestConstantsUsage(t *testing.T) {
+	t.Run("verify constants are defined and used", func(t *testing.T) {
+		// Test that constants are defined
+		assert.Equal(t, "instantiate", types.ActionInstantiate)
+		assert.Equal(t, "add_to_allowlist", types.ActionAddToAllowlist)
+		assert.Equal(t, "remove_from_allowlist", types.ActionRemoveFromAllowlist)
+
+		// Test that they work with our functions
+		srv := &Service{}
+		bsn := &model.BSN{}
+
+		// Test each constant works with computeAllowlistChanges
+		added, removed := srv.computeAllowlistChanges(bsn, []string{"test"}, types.ActionInstantiate)
+		assert.Equal(t, []string{"test"}, added)
+		assert.Empty(t, removed) // Empty slice, not nil
+
+		added, removed = srv.computeAllowlistChanges(bsn, []string{"test"}, types.ActionAddToAllowlist)
+		assert.Equal(t, []string{"test"}, added)
+		assert.Nil(t, removed)
+
+		added, removed = srv.computeAllowlistChanges(bsn, []string{"test"}, types.ActionRemoveFromAllowlist)
+		assert.Nil(t, added)
+		assert.Equal(t, []string{"test"}, removed)
+	})
+}

--- a/internal/services/testdata/events/add_allowlist.json
+++ b/internal/services/testdata/events/add_allowlist.json
@@ -1,0 +1,20 @@
+[
+  {
+    "type": "wasm",
+    "attributes": [
+      { "key": "_contract_address", "value": "bbn1t3f58anpzq02plqc45rmj3ws2kwqjvrxwtac3l2dhnrpvrvd98wq6sdmhw", "index": true },
+      { "key": "action", "value": "add_to_allowlist", "index": true },
+      { "key": "num_added", "value": "1", "index": true },
+      { "key": "msg_index", "value": "0", "index": true }
+    ]
+  },
+  {
+    "type": "wasm-add_to_allowlist",
+    "attributes": [
+      { "key": "_contract_address", "value": "bbn1t3f58anpzq02plqc45rmj3ws2kwqjvrxwtac3l2dhnrpvrvd98wq6sdmhw", "index": true },
+      { "key": "fp_pubkeys", "value": "c0cb443053ec80ea62888abe2fe22b005620fac6ed3df905a6268eb41e286580", "index": true },
+      { "key": "msg_index", "value": "0", "index": true }
+    ]
+  }
+]
+

--- a/internal/services/testdata/events/initiate_allowlist.json
+++ b/internal/services/testdata/events/initiate_allowlist.json
@@ -1,0 +1,12 @@
+[
+  {
+    "type": "wasm",
+    "attributes": [
+      { "key": "_contract_address", "value": "bbn1t3f58anpzq02plqc45rmj3ws2kwqjvrxwtac3l2dhnrpvrvd98wq6sdmhw", "index": true },
+      { "key": "action", "value": "instantiate", "index": true },
+      { "key": "allow-list", "value": "531984e1715a7f5acc58e362fdf81d5fe6176f3f4e052a22e71a7089a7e912a7,c0cb443053ec80ea62888abe2fe22b005620fac6ed3df905a6268eb41e286580,5a9b6299e5ad13de0e6acbd9f92aa4e89017fe13cb04183263c765f7fdb3aa2d", "index": true },
+      { "key": "msg_index", "value": "0", "index": true }
+    ]
+  }
+]
+

--- a/internal/services/testdata/events/remove_allowlist.json
+++ b/internal/services/testdata/events/remove_allowlist.json
@@ -1,0 +1,20 @@
+[
+  {
+    "type": "wasm",
+    "attributes": [
+      { "key": "_contract_address", "value": "bbn1t3f58anpzq02plqc45rmj3ws2kwqjvrxwtac3l2dhnrpvrvd98wq6sdmhw", "index": true },
+      { "key": "action", "value": "remove_from_allowlist", "index": true },
+      { "key": "num_removed", "value": "1", "index": true },
+      { "key": "msg_index", "value": "0", "index": true }
+    ]
+  },
+  {
+    "type": "wasm-remove_from_allowlist",
+    "attributes": [
+      { "key": "_contract_address", "value": "bbn1t3f58anpzq02plqc45rmj3ws2kwqjvrxwtac3l2dhnrpvrvd98wq6sdmhw", "index": true },
+      { "key": "fp_pubkeys", "value": "c0cb443053ec80ea62888abe2fe22b005620fac6ed3df905a6268eb41e286580", "index": true },
+      { "key": "msg_index", "value": "0", "index": true }
+    ]
+  }
+]
+

--- a/internal/types/event.go
+++ b/internal/types/event.go
@@ -27,6 +27,12 @@ const (
 
 const EventConsumerRegistered EventType = "babylon.btcstkconsumer.v1.EventConsumerRegistered"
 
+const (
+	EventWasm                    EventType = "wasm"
+	EventWasmAddToAllowlist      EventType = "wasm-add_to_allowlist"
+	EventWasmRemoveFromAllowlist EventType = "wasm-remove_from_allowlist"
+)
+
 // ShortName returns the event name without the "babylon.btcstaking.v1." prefix
 // e.g., "babylon.btcstaking.v1.EventBTCDelegationCreated" -> "EventBTCDelegationCreated"
 func (e EventType) ShortName() string {

--- a/internal/types/rollup_fp_allowlist.go
+++ b/internal/types/rollup_fp_allowlist.go
@@ -1,0 +1,132 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+
+	abcitypes "github.com/cometbft/cometbft/abci/types"
+)
+
+// Allowlist-related event types for CosmWasm contract events
+const (
+	// Contract instantiation events
+	EventWasmInstantiate EventType = "instantiate"
+	EventWasm            EventType = "wasm"
+
+	// Allowlist mutation events
+	EventWasmAddToAllowlist      EventType = "wasm-add_to_allowlist"
+	EventWasmRemoveFromAllowlist EventType = "wasm-remove_from_allowlist"
+)
+
+// AllowlistEvent represents a parsed allowlist-related event
+type AllowlistEvent struct {
+	EventType  EventType `json:"event_type"`
+	Address    string    `json:"address"`
+	Action     string    `json:"action,omitempty"`
+	FpPubkeys  []string  `json:"fp_pubkeys,omitempty"`
+	AllowList  []string  `json:"allow_list,omitempty"`
+	NumAdded   string    `json:"num_added,omitempty"`
+	NumRemoved string    `json:"num_removed,omitempty"`
+	MsgIndex   string    `json:"msg_index,omitempty"`
+}
+
+// ParseAllowlistFromString parses a comma-separated string of BTC public keys
+func ParseAllowlistFromString(allowlistStr string) []string {
+	if allowlistStr == "" {
+		return []string{}
+	}
+
+	// Split by comma and trim whitespace
+	pubkeys := strings.Split(allowlistStr, ",")
+	result := make([]string, 0, len(pubkeys))
+
+	for _, pubkey := range pubkeys {
+		trimmed := strings.TrimSpace(pubkey)
+		if trimmed != "" {
+			// Normalize to lowercase for consistent storage
+			result = append(result, strings.ToLower(trimmed))
+		}
+	}
+
+	return result
+}
+
+// ParseAllowlistEvent parses ABCI events into AllowlistEvent structs
+func ParseAllowlistEvent(event abcitypes.Event) (*AllowlistEvent, error) {
+	eventType := EventType(event.Type)
+
+	// Only process allowlist-related events
+	if !IsAllowlistEvent(eventType) {
+		return nil, fmt.Errorf("not an allowlist event: %s", eventType)
+	}
+
+	allowlistEvent := &AllowlistEvent{
+		EventType: eventType,
+	}
+
+	// Parse attributes
+	for _, attr := range event.Attributes {
+		switch attr.Key {
+		case "_contract_address":
+			allowlistEvent.Address = attr.Value
+		case "action":
+			allowlistEvent.Action = attr.Value
+		case "fp_pubkeys":
+			allowlistEvent.FpPubkeys = ParseAllowlistFromString(attr.Value)
+		case "allow-list":
+			allowlistEvent.AllowList = ParseAllowlistFromString(attr.Value)
+		case "num_added":
+			allowlistEvent.NumAdded = attr.Value
+		case "num_removed":
+			allowlistEvent.NumRemoved = attr.Value
+		case "msg_index":
+			allowlistEvent.MsgIndex = attr.Value
+		}
+	}
+
+	// Validate required fields
+	if allowlistEvent.Address == "" {
+		return nil, fmt.Errorf("missing address in allowlist event")
+	}
+
+	return allowlistEvent, nil
+}
+
+// IsAllowlistEvent checks if the event type is allowlist-related
+func IsAllowlistEvent(eventType EventType) bool {
+	switch eventType {
+	case EventWasmInstantiate, EventWasm, EventWasmAddToAllowlist, EventWasmRemoveFromAllowlist:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsInstantiateEvent checks if this is a contract instantiation event
+func (e *AllowlistEvent) IsInstantiateEvent() bool {
+	return (e.EventType == EventWasm && e.Action == "instantiate") ||
+		e.EventType == EventWasmInstantiate
+}
+
+// IsAddEvent checks if this is an add to allowlist event
+func (e *AllowlistEvent) IsAddEvent() bool {
+	return e.EventType == EventWasmAddToAllowlist ||
+		(e.EventType == EventWasm && e.Action == "add_to_allowlist")
+}
+
+// IsRemoveEvent checks if this is a remove from allowlist event
+func (e *AllowlistEvent) IsRemoveEvent() bool {
+	return e.EventType == EventWasmRemoveFromAllowlist ||
+		(e.EventType == EventWasm && e.Action == "remove_from_allowlist")
+}
+
+// GetPubkeys returns the relevant public keys for this event
+func (e *AllowlistEvent) GetPubkeys() []string {
+	if len(e.FpPubkeys) > 0 {
+		return e.FpPubkeys
+	}
+	if len(e.AllowList) > 0 {
+		return e.AllowList
+	}
+	return []string{}
+}

--- a/internal/types/rollup_fp_allowlist.go
+++ b/internal/types/rollup_fp_allowlist.go
@@ -50,7 +50,6 @@ func ParseAllowlistFromString(allowlistStr string) []string {
 	return result
 }
 
-// ParseAllowlistEvent parses ABCI events into AllowlistEvent structs
 func ParseAllowlistEvent(event abcitypes.Event) (*AllowlistEvent, error) {
 	eventType := EventType(event.Type)
 

--- a/internal/types/rollup_fp_allowlist_test.go
+++ b/internal/types/rollup_fp_allowlist_test.go
@@ -1,0 +1,236 @@
+package types
+
+import (
+	"testing"
+
+	abcitypes "github.com/cometbft/cometbft/abci/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAllowlistFromString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: []string{},
+		},
+		{
+			name:     "single pubkey",
+			input:    "d87687800cf9e51026a787339d9de9dae3e4dbed9aca7167f0c100f39e8788cf",
+			expected: []string{"d87687800cf9e51026a787339d9de9dae3e4dbed9aca7167f0c100f39e8788cf"},
+		},
+		{
+			name:  "multiple pubkeys",
+			input: "d87687800cf9e51026a787339d9de9dae3e4dbed9aca7167f0c100f39e8788cf,eb70add112d8b289231da8dcc448bdadfc8fce9d1a1db113650dbc7aa01fe8c1",
+			expected: []string{
+				"d87687800cf9e51026a787339d9de9dae3e4dbed9aca7167f0c100f39e8788cf",
+				"eb70add112d8b289231da8dcc448bdadfc8fce9d1a1db113650dbc7aa01fe8c1",
+			},
+		},
+		{
+			name:  "pubkeys with whitespace",
+			input: " d87687800cf9e51026a787339d9de9dae3e4dbed9aca7167f0c100f39e8788cf , eb70add112d8b289231da8dcc448bdadfc8fce9d1a1db113650dbc7aa01fe8c1 ",
+			expected: []string{
+				"d87687800cf9e51026a787339d9de9dae3e4dbed9aca7167f0c100f39e8788cf",
+				"eb70add112d8b289231da8dcc448bdadfc8fce9d1a1db113650dbc7aa01fe8c1",
+			},
+		},
+		{
+			name:     "uppercase pubkeys (should normalize to lowercase)",
+			input:    "D87687800CF9E51026A787339D9DE9DAE3E4DBED9ACA7167F0C100F39E8788CF",
+			expected: []string{"d87687800cf9e51026a787339d9de9dae3e4dbed9aca7167f0c100f39e8788cf"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseAllowlistFromString(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParseAllowlistEvent(t *testing.T) {
+	tests := []struct {
+		name        string
+		event       abcitypes.Event
+		expected    *AllowlistEvent
+		expectError bool
+	}{
+		{
+			name: "instantiate event with allow-list",
+			event: abcitypes.Event{
+				Type: "wasm",
+				Attributes: []abcitypes.EventAttribute{
+					{Key: "_contract_address", Value: "bbn186hnxztn0gh7090rqjuvw8ln6zw08qt4q88jl6ed2tlzhfhq4hpq2n92jj"},
+					{Key: "action", Value: "instantiate"},
+					{Key: "allow-list", Value: "d87687800cf9e51026a787339d9de9dae3e4dbed9aca7167f0c100f39e8788cf,eb70add112d8b289231da8dcc448bdadfc8fce9d1a1db113650dbc7aa01fe8c1"},
+					{Key: "msg_index", Value: "0"},
+				},
+			},
+			expected: &AllowlistEvent{
+				EventType: EventWasm,
+				Address:   "bbn186hnxztn0gh7090rqjuvw8ln6zw08qt4q88jl6ed2tlzhfhq4hpq2n92jj",
+				Action:    "instantiate",
+				AllowList: []string{
+					"d87687800cf9e51026a787339d9de9dae3e4dbed9aca7167f0c100f39e8788cf",
+					"eb70add112d8b289231da8dcc448bdadfc8fce9d1a1db113650dbc7aa01fe8c1",
+				},
+				MsgIndex: "0",
+			},
+			expectError: false,
+		},
+		{
+			name: "add to allowlist event",
+			event: abcitypes.Event{
+				Type: "wasm-add_to_allowlist",
+				Attributes: []abcitypes.EventAttribute{
+					{Key: "_contract_address", Value: "bbn186hnxztn0gh7090rqjuvw8ln6zw08qt4q88jl6ed2tlzhfhq4hpq2n92jj"},
+					{Key: "fp_pubkeys", Value: "d87687800cf9e51026a787339d9de9dae3e4dbed9aca7167f0c100f39e8788cf"},
+					{Key: "msg_index", Value: "0"},
+				},
+			},
+			expected: &AllowlistEvent{
+				EventType: EventWasmAddToAllowlist,
+				Address:   "bbn186hnxztn0gh7090rqjuvw8ln6zw08qt4q88jl6ed2tlzhfhq4hpq2n92jj",
+				FpPubkeys: []string{"d87687800cf9e51026a787339d9de9dae3e4dbed9aca7167f0c100f39e8788cf"},
+				MsgIndex:  "0",
+			},
+			expectError: false,
+		},
+		{
+			name: "remove from allowlist event",
+			event: abcitypes.Event{
+				Type: "wasm-remove_from_allowlist",
+				Attributes: []abcitypes.EventAttribute{
+					{Key: "_contract_address", Value: "bbn186hnxztn0gh7090rqjuvw8ln6zw08qt4q88jl6ed2tlzhfhq4hpq2n92jj"},
+					{Key: "fp_pubkeys", Value: "d87687800cf9e51026a787339d9de9dae3e4dbed9aca7167f0c100f39e8788cf"},
+					{Key: "msg_index", Value: "0"},
+				},
+			},
+			expected: &AllowlistEvent{
+				EventType: EventWasmRemoveFromAllowlist,
+				Address:   "bbn186hnxztn0gh7090rqjuvw8ln6zw08qt4q88jl6ed2tlzhfhq4hpq2n92jj",
+				FpPubkeys: []string{"d87687800cf9e51026a787339d9de9dae3e4dbed9aca7167f0c100f39e8788cf"},
+				MsgIndex:  "0",
+			},
+			expectError: false,
+		},
+		{
+			name: "non-allowlist event",
+			event: abcitypes.Event{
+				Type: "transfer",
+				Attributes: []abcitypes.EventAttribute{
+					{Key: "recipient", Value: "some_address"},
+				},
+			},
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name: "allowlist event missing contract address",
+			event: abcitypes.Event{
+				Type: "wasm",
+				Attributes: []abcitypes.EventAttribute{
+					{Key: "action", Value: "instantiate"},
+				},
+			},
+			expected:    nil,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ParseAllowlistEvent(tt.event)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestAllowlistEventMethods(t *testing.T) {
+	tests := []struct {
+		name          string
+		event         AllowlistEvent
+		isInstantiate bool
+		isAdd         bool
+		isRemove      bool
+		pubkeys       []string
+	}{
+		{
+			name: "instantiate event",
+			event: AllowlistEvent{
+				EventType: EventWasm,
+				Action:    "instantiate",
+				AllowList: []string{"pubkey1", "pubkey2"},
+			},
+			isInstantiate: true,
+			isAdd:         false,
+			isRemove:      false,
+			pubkeys:       []string{"pubkey1", "pubkey2"},
+		},
+		{
+			name: "add event",
+			event: AllowlistEvent{
+				EventType: EventWasmAddToAllowlist,
+				FpPubkeys: []string{"pubkey3"},
+			},
+			isInstantiate: false,
+			isAdd:         true,
+			isRemove:      false,
+			pubkeys:       []string{"pubkey3"},
+		},
+		{
+			name: "remove event",
+			event: AllowlistEvent{
+				EventType: EventWasmRemoveFromAllowlist,
+				FpPubkeys: []string{"pubkey4"},
+			},
+			isInstantiate: false,
+			isAdd:         false,
+			isRemove:      true,
+			pubkeys:       []string{"pubkey4"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.isInstantiate, tt.event.IsInstantiateEvent())
+			assert.Equal(t, tt.isAdd, tt.event.IsAddEvent())
+			assert.Equal(t, tt.isRemove, tt.event.IsRemoveEvent())
+			assert.Equal(t, tt.pubkeys, tt.event.GetPubkeys())
+		})
+	}
+}
+
+func TestIsAllowlistEvent(t *testing.T) {
+	tests := []struct {
+		eventType EventType
+		expected  bool
+	}{
+		{EventWasmInstantiate, true},
+		{EventWasm, true},
+		{EventWasmAddToAllowlist, true},
+		{EventWasmRemoveFromAllowlist, true},
+		{EventBTCDelegationCreated, false},
+		{EventType("transfer"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.eventType), func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsAllowlistEvent(tt.eventType))
+		})
+	}
+}

--- a/tests/mocks/mock_db_client.go
+++ b/tests/mocks/mock_db_client.go
@@ -563,6 +563,42 @@ func (_m *DbInterface) UpdateStakingParamMaxFinalityProviders(ctx context.Contex
 		r0 = ret.Error(0)
 	}
 
+return r0
+}
+
+// RecomputeFPAllowlistedForBSN provides a mock function with given fields: ctx, bsnID, allowlist
+func (_m *DbInterface) RecomputeFPAllowlistedForBSN(ctx context.Context, bsnID string, allowlist []string) error {
+	ret := _m.Called(ctx, bsnID, allowlist)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RecomputeFPAllowlistedForBSN")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, []string) error); ok {
+		r0 = rf(ctx, bsnID, allowlist)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SetFPAllowlisted provides a mock function with given fields: ctx, bsnID, btcPks, value
+func (_m *DbInterface) SetFPAllowlisted(ctx context.Context, bsnID string, btcPks []string, value bool) error {
+	ret := _m.Called(ctx, bsnID, btcPks, value)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetFPAllowlisted")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, []string, bool) error); ok {
+		r0 = rf(ctx, bsnID, btcPks, value)
+	} else {
+		r0 = ret.Error(0)
+	}
+
 	return r0
 }
 


### PR DESCRIPTION
### Allowlist support for BSNs and Finality Providers

* Added an `Allowlist` field to the `ETHL2Metadata` struct in `BSN` and implemented helper methods (`UpdateAllowlistFromEvent`, `mergeAllowlist`, `removeFromAllowlist`, and normalization utilities) to manage allowlist updates based on events (`ActionInstantiate`, `ActionAddToAllowlist`, `ActionRemoveFromAllowlist`). (`internal/db/model/bsn.go`) [[1]](diffhunk://#diff-0b8818f4c5cc2675ef92cc2de90b42cd86e5320b1f18625b64c36379555bf946R20) [[2]](diffhunk://#diff-0b8818f4c5cc2675ef92cc2de90b42cd86e5320b1f18625b64c36379555bf946R39-R127)
* Added an `IsAllowlisted` boolean field to `FinalityProviderDetails` to track allowlist status per FP, and ensured all BTC public keys are stored in lowercase for consistency. (`internal/db/model/finality_provider.go`) [[1]](diffhunk://#diff-53266e237f0f1b44f6a561bd1cc0f99664f90fa2e8a2dbd04106466a053ed37bR16) [[2]](diffhunk://#diff-53266e237f0f1b44f6a561bd1cc0f99664f90fa2e8a2dbd04106466a053ed37bL27-R32) [[3]](diffhunk://#diff-53266e237f0f1b44f6a561bd1cc0f99664f90fa2e8a2dbd04106466a053ed37bL46-R51)

### DB and interface

* Implemented new database methods for fetching a BSN by its contract address, updating a BSN's allowlist, setting FP allowlist flags, and recomputing FP allowlist status for a BSN. These are exposed via the `DbInterface` and wrapped with metrics in `DbWithMetrics`. (`internal/db/bsn.go`, `internal/db/finality_provider_allowlist.go`, `internal/db/interface.go`, `internal/db/metrics.go`) [[1]](diffhunk://#diff-c64d36715067d17d8382b2fae760240f73650326bb452b797b5daabd6d1627b2R55-R117) [[2]](diffhunk://#diff-31e289fc14e569c48f924cc56434e364946366bb10b03f857ca8115686abaee9R1-R52) [[3]](diffhunk://#diff-075543dfda1bf47a68c2465478d57d160f373505a0fc20854becc3e64df30416R221-R256) [[4]](diffhunk://#diff-4047e45831f77d519157ad87fac69209f3f12ec7d0e4c9110c15f2394ea13fb4R220-R245)

### Event processing for allowlist changes

* Added new event handlers to process contract instantiation and allowlist update events, updating both the BSN allowlist and FP records accordingly. This includes logic to compute added/removed pubkeys and update the relevant database records. (`internal/services/events.go`, `internal/services/rollup_fp_allowlist.go`) [[1]](diffhunk://#diff-e176b61a073f9d2b8c515d6b3fd7ecd2a13d35055c7d1cda50e19f768cf5315bR109-R117) [[2]](diffhunk://#diff-891b7c3e962009aa9c6f7dd1ba755319a251ce131dc31905618e948f104bd090R1-R209)

### Indexing and performance improvements

* Added new MongoDB indexes for efficient querying by contract address and BSN ID in both the `BSN` and `FinalityProviderDetails` collections. (`internal/db/model/setup.go`) [[1]](diffhunk://#diff-939ab04b7acb6b5cfea140a32cfc0157bfb5af2a76d69966e2c5a4c11ee4f4dcL32-R35) [[2]](diffhunk://#diff-939ab04b7acb6b5cfea140a32cfc0157bfb5af2a76d69966e2c5a4c11ee4f4dcR53-R55)