### PR TITLE
fix: should stop processing other FP status event if already slashed 2

### DIFF
--- a/internal/types/error.go
+++ b/internal/types/error.go
@@ -62,3 +62,6 @@ func NewInternalServiceError(err error) *Error {
 
 // ErrInvalidUnbondingTx the transaction spends the unbonding path but is invalid
 var ErrInvalidUnbondingTx = errors.New("invalid unbonding tx")
+
+// ErrFinalityProviderAlreadySlashed is returned when a finality provider is already slashed, cannot change state, ignoring event
+var ErrFinalityProviderAlreadySlashed = errors.New("finality provider is already slashed, cannot change state, ignoring event")


### PR DESCRIPTION
This PR fixes an issue left over from a previous PR, where event execution wasn’t properly exited.

For FPs that are already slashed, we will now ignore any subsequent FP status change events.