### PR TITLE
fix(security): validate JSON and add bounds checks to prevent indexer…

### DIFF
--- a/e2etest/container/container.go
+++ b/e2etest/container/container.go
@@ -54,7 +54,8 @@ func NewManager(t *testing.T) (docker *Manager, err error) {
 
 func (m *Manager) ExecBitcoindCliCmd(t *testing.T, command []string) (bytes.Buffer, bytes.Buffer, error) {
 	// this is currently hardcoded, as it will be the same for all tests
-	cmd := []string{"bitcoin-cli", "-chain=regtest", "-rpcuser=user", "-rpcpassword=pass"}
+	cmd := make([]string, 0, 4+len(command))
+	cmd = append(cmd, "bitcoin-cli", "-chain=regtest", "-rpcuser=user", "-rpcpassword=pass")
 	cmd = append(cmd, command...)
 	return m.ExecCmd(t, bitcoindContainerName, cmd)
 }

--- a/internal/clients/bbnclient/bbnclient.go
+++ b/internal/clients/bbnclient/bbnclient.go
@@ -218,7 +218,7 @@ func (c *BBNClient) Subscribe(
 		close(eventChan)
 		return nil, err
 	}
-	go func() {
+	go func() { //nolint:gosec // G118: subscription goroutine intentionally uses context.Background to outlive request ctx
 		defer close(eventChan)
 		timeoutTicker := time.NewTicker(healthCheckInterval)
 		defer timeoutTicker.Stop()

--- a/internal/db/model/delegation.go
+++ b/internal/db/model/delegation.go
@@ -106,7 +106,7 @@ func FromEventBTCDelegationCreated(
 		log.Warn().Stringer("staking_tx_hash_hex", stakingTx.TxHash()).Msg("Staker address is empty")
 	}
 
-	if int(stakingOutputIdx) >= len(stakingTx.TxOut) {
+	if uint64(stakingOutputIdx) >= uint64(len(stakingTx.TxOut)) {
 		return nil, fmt.Errorf("staking output index %d out of range (tx has %d outputs)", stakingOutputIdx, len(stakingTx.TxOut))
 	}
 	stakingValue := btcutil.Amount(stakingTx.TxOut[stakingOutputIdx].Value)

--- a/internal/db/model/delegation.go
+++ b/internal/db/model/delegation.go
@@ -106,6 +106,9 @@ func FromEventBTCDelegationCreated(
 		log.Warn().Stringer("staking_tx_hash_hex", stakingTx.TxHash()).Msg("Staker address is empty")
 	}
 
+	if int(stakingOutputIdx) >= len(stakingTx.TxOut) {
+		return nil, fmt.Errorf("staking output index %d out of range (tx has %d outputs)", stakingOutputIdx, len(stakingTx.TxOut))
+	}
 	stakingValue := btcutil.Amount(stakingTx.TxOut[stakingOutputIdx].Value)
 
 	return &BTCDelegationDetails{

--- a/internal/db/model/delegation_test.go
+++ b/internal/db/model/delegation_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"bytes"
 	"encoding/hex"
 	"testing"
 
@@ -21,18 +22,16 @@ func TestFromEventBTCDelegationCreated_StakingOutputIdxOutOfRange(t *testing.T) 
 		PkScript: []byte{0x00, 0x14, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14},
 	})
 
-	var buf []byte
-	w := new(wireBuffer)
-	err := tx.Serialize(w)
+	var buf bytes.Buffer
+	err := tx.Serialize(&buf)
 	require.NoError(t, err)
-	buf = w.bytes
 
-	stakingTxHex := hex.EncodeToString(buf)
+	stakingTxHex := hex.EncodeToString(buf.Bytes())
 
 	tests := []struct {
-		name           string
-		stakingOutIdx  string
-		wantErr        string
+		name          string
+		stakingOutIdx string
+		wantErr       string
 	}{
 		{
 			name:          "output index equals output count",
@@ -75,14 +74,4 @@ func TestFromEventBTCDelegationCreated_StakingOutputIdxOutOfRange(t *testing.T) 
 			}
 		})
 	}
-}
-
-// wireBuffer is a simple io.Writer that accumulates bytes for serialization.
-type wireBuffer struct {
-	bytes []byte
-}
-
-func (w *wireBuffer) Write(p []byte) (int, error) {
-	w.bytes = append(w.bytes, p...)
-	return len(p), nil
 }

--- a/internal/db/model/delegation_test.go
+++ b/internal/db/model/delegation_test.go
@@ -1,0 +1,88 @@
+package model
+
+import (
+	"encoding/hex"
+	"testing"
+
+	bbntypes "github.com/babylonlabs-io/babylon/v4/x/btcstaking/types"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFromEventBTCDelegationCreated_StakingOutputIdxOutOfRange(t *testing.T) {
+	// Build a minimal valid BTC transaction with 1 output
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{Index: 0},
+	})
+	tx.AddTxOut(&wire.TxOut{
+		Value:    10000,
+		PkScript: []byte{0x00, 0x14, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14},
+	})
+
+	var buf []byte
+	w := new(wireBuffer)
+	err := tx.Serialize(w)
+	require.NoError(t, err)
+	buf = w.bytes
+
+	stakingTxHex := hex.EncodeToString(buf)
+
+	tests := []struct {
+		name           string
+		stakingOutIdx  string
+		wantErr        string
+	}{
+		{
+			name:          "output index equals output count",
+			stakingOutIdx: "1",
+			wantErr:       "staking output index 1 out of range (tx has 1 outputs)",
+		},
+		{
+			name:          "output index far exceeds output count",
+			stakingOutIdx: "999",
+			wantErr:       "staking output index 999 out of range (tx has 1 outputs)",
+		},
+		{
+			name:          "valid output index 0",
+			stakingOutIdx: "0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := &bbntypes.EventBTCDelegationCreated{
+				StakingTxHex:       stakingTxHex,
+				StakingOutputIndex: tt.stakingOutIdx,
+				ParamsVersion:      "0",
+				StakingTime:        "1000",
+				UnbondingTime:      "100",
+				UnbondingTx:        "",
+				StakerBtcPkHex:     "aabbccdd",
+				StakerAddr:         "bbn1test",
+				NewState:           "PENDING",
+			}
+
+			result, err := FromEventBTCDelegationCreated(event, 100, 1000)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+			}
+		})
+	}
+}
+
+// wireBuffer is a simple io.Writer that accumulates bytes for serialization.
+type wireBuffer struct {
+	bytes []byte
+}
+
+func (w *wireBuffer) Write(p []byte) (int, error) {
+	w.bytes = append(w.bytes, p...)
+	return len(p), nil
+}

--- a/internal/services/bounds_check_test.go
+++ b/internal/services/bounds_check_test.go
@@ -1,0 +1,101 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_extractScriptFromWitness(t *testing.T) {
+	tests := []struct {
+		name      string
+		tx        *wire.MsgTx
+		inputIdx  uint32
+		wantErr   string
+		wantBytes []byte
+	}{
+		{
+			name:     "no inputs",
+			tx:       &wire.MsgTx{TxIn: []*wire.TxIn{}},
+			inputIdx: 0,
+			wantErr:  "input index 0 out of range (tx has 0 inputs)",
+		},
+		{
+			name: "input index out of range",
+			tx: &wire.MsgTx{
+				TxIn: []*wire.TxIn{
+					{Witness: wire.TxWitness{[]byte("a"), []byte("b")}},
+				},
+			},
+			inputIdx: 5,
+			wantErr:  "input index 5 out of range (tx has 1 inputs)",
+		},
+		{
+			name: "witness has 0 elements",
+			tx: &wire.MsgTx{
+				TxIn: []*wire.TxIn{
+					{Witness: wire.TxWitness{}},
+				},
+			},
+			inputIdx: 0,
+			wantErr:  "spending tx input 0 has 0 witness elements, expected at least 2",
+		},
+		{
+			name: "witness has 1 element",
+			tx: &wire.MsgTx{
+				TxIn: []*wire.TxIn{
+					{Witness: wire.TxWitness{[]byte("only_one")}},
+				},
+			},
+			inputIdx: 0,
+			wantErr:  "spending tx input 0 has 1 witness elements, expected at least 2",
+		},
+		{
+			name: "witness has exactly 2 elements - returns first",
+			tx: &wire.MsgTx{
+				TxIn: []*wire.TxIn{
+					{Witness: wire.TxWitness{[]byte("script"), []byte("sig")}},
+				},
+			},
+			inputIdx:  0,
+			wantBytes: []byte("script"),
+		},
+		{
+			name: "witness has 3 elements - returns second to last",
+			tx: &wire.MsgTx{
+				TxIn: []*wire.TxIn{
+					{Witness: wire.TxWitness{[]byte("a"), []byte("script"), []byte("control_block")}},
+				},
+			},
+			inputIdx:  0,
+			wantBytes: []byte("script"),
+		},
+		{
+			name: "non-zero input index success",
+			tx: &wire.MsgTx{
+				TxIn: []*wire.TxIn{
+					{Witness: wire.TxWitness{[]byte("a"), []byte("b")}},
+					{Witness: wire.TxWitness{[]byte("x"), []byte("target_script"), []byte("z")}},
+				},
+			},
+			inputIdx:  1,
+			wantBytes: []byte("target_script"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractScriptFromWitness(tt.tx, tt.inputIdx)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Nil(t, got)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantBytes, got)
+			}
+		})
+	}
+}

--- a/internal/services/delegation.go
+++ b/internal/services/delegation.go
@@ -190,7 +190,10 @@ func (s *Service) processBTCDelegationInclusionProofReceivedEvent(
 	}
 	newState := types.DelegationState(inclusionProofEvent.NewState)
 	if newState == types.StateActive {
-		stakingStartHeight, _ := utils.ParseUint32(inclusionProofEvent.StartHeight)
+		stakingStartHeight, err := utils.ParseUint32(inclusionProofEvent.StartHeight)
+		if err != nil {
+			return fmt.Errorf("failed to parse staking start height: %w", err)
+		}
 
 		log.Debug().
 			Str("staking_tx", inclusionProofEvent.StakingTxHash).
@@ -216,8 +219,14 @@ func (s *Service) processBTCDelegationInclusionProofReceivedEvent(
 		}
 	}
 
-	stakingStartHeight, _ := utils.ParseUint32(inclusionProofEvent.StartHeight)
-	stakingEndHeight, _ := utils.ParseUint32(inclusionProofEvent.EndHeight)
+	stakingStartHeight, err := utils.ParseUint32(inclusionProofEvent.StartHeight)
+	if err != nil {
+		return fmt.Errorf("failed to parse staking start height: %w", err)
+	}
+	stakingEndHeight, err := utils.ParseUint32(inclusionProofEvent.EndHeight)
+	if err != nil {
+		return fmt.Errorf("failed to parse staking end height: %w", err)
+	}
 	stakingBtcTimestamp, err := s.btc.GetBlockTimestamp(ctx, stakingStartHeight)
 	if err != nil {
 		return fmt.Errorf("failed to get block timestamp: %w", err)

--- a/internal/services/delegation.go
+++ b/internal/services/delegation.go
@@ -183,6 +183,17 @@ func (s *Service) processBTCDelegationInclusionProofReceivedEvent(
 
 	log := log.Ctx(ctx)
 
+	// Parse and validate all heights before any side effects to avoid partial
+	// state changes on retry (e.g. duplicate events emitted while DB update fails).
+	stakingStartHeight, err := utils.ParseUint32(inclusionProofEvent.StartHeight)
+	if err != nil {
+		return fmt.Errorf("failed to parse staking start height: %w", err)
+	}
+	stakingEndHeight, err := utils.ParseUint32(inclusionProofEvent.EndHeight)
+	if err != nil {
+		return fmt.Errorf("failed to parse staking end height: %w", err)
+	}
+
 	// Emit event and register spend notification
 	delegation, dbErr := s.db.GetBTCDelegationByStakingTxHash(ctx, inclusionProofEvent.StakingTxHash)
 	if dbErr != nil {
@@ -190,11 +201,6 @@ func (s *Service) processBTCDelegationInclusionProofReceivedEvent(
 	}
 	newState := types.DelegationState(inclusionProofEvent.NewState)
 	if newState == types.StateActive {
-		stakingStartHeight, err := utils.ParseUint32(inclusionProofEvent.StartHeight)
-		if err != nil {
-			return fmt.Errorf("failed to parse staking start height: %w", err)
-		}
-
 		log.Debug().
 			Str("staking_tx", inclusionProofEvent.StakingTxHash).
 			Str("staking_start_height", inclusionProofEvent.StartHeight).
@@ -217,15 +223,6 @@ func (s *Service) processBTCDelegationInclusionProofReceivedEvent(
 		); err != nil {
 			return err
 		}
-	}
-
-	stakingStartHeight, err := utils.ParseUint32(inclusionProofEvent.StartHeight)
-	if err != nil {
-		return fmt.Errorf("failed to parse staking start height: %w", err)
-	}
-	stakingEndHeight, err := utils.ParseUint32(inclusionProofEvent.EndHeight)
-	if err != nil {
-		return fmt.Errorf("failed to parse staking end height: %w", err)
 	}
 	stakingBtcTimestamp, err := s.btc.GetBlockTimestamp(ctx, stakingStartHeight)
 	if err != nil {

--- a/internal/services/delegation_helpers.go
+++ b/internal/services/delegation_helpers.go
@@ -34,8 +34,8 @@ func (s *Service) registerUnbondingSpendNotification(
 		Stringer("unbonding_tx", unbondingTx.TxHash()).
 		Msg("registering early unbonding spend notification")
 
-	if len(unbondingTx.TxOut) == 0 {
-		return fmt.Errorf("unbonding tx has no outputs for staking tx %s", delegation.StakingTxHashHex)
+	if len(unbondingTx.TxOut) != 1 {
+		return fmt.Errorf("unbonding tx has %d outputs, expected exactly 1 for staking tx %s", len(unbondingTx.TxOut), delegation.StakingTxHashHex)
 	}
 
 	unbondingOutpoint := wire.OutPoint{
@@ -84,7 +84,7 @@ func (s *Service) registerStakingSpendNotification(
 		return fmt.Errorf("failed to deserialize staking tx: %w", err)
 	}
 
-	if int(stakingOutputIdx) >= len(stakingTx.TxOut) {
+	if uint64(stakingOutputIdx) >= uint64(len(stakingTx.TxOut)) {
 		return fmt.Errorf("staking output index %d out of range (tx has %d outputs)", stakingOutputIdx, len(stakingTx.TxOut))
 	}
 

--- a/internal/services/delegation_helpers.go
+++ b/internal/services/delegation_helpers.go
@@ -34,6 +34,10 @@ func (s *Service) registerUnbondingSpendNotification(
 		Stringer("unbonding_tx", unbondingTx.TxHash()).
 		Msg("registering early unbonding spend notification")
 
+	if len(unbondingTx.TxOut) == 0 {
+		return fmt.Errorf("unbonding tx has no outputs for staking tx %s", delegation.StakingTxHashHex)
+	}
+
 	unbondingOutpoint := wire.OutPoint{
 		Hash:  unbondingTx.TxHash(),
 		Index: 0, // unbonding tx has only 1 output
@@ -78,6 +82,10 @@ func (s *Service) registerStakingSpendNotification(
 	stakingTx, err := utils.DeserializeBtcTransactionFromHex(stakingTxHex)
 	if err != nil {
 		return fmt.Errorf("failed to deserialize staking tx: %w", err)
+	}
+
+	if int(stakingOutputIdx) >= len(stakingTx.TxOut) {
+		return fmt.Errorf("staking output index %d out of range (tx has %d outputs)", stakingOutputIdx, len(stakingTx.TxOut))
 	}
 
 	stakingOutpoint := wire.OutPoint{

--- a/internal/services/events.go
+++ b/internal/services/events.go
@@ -368,7 +368,14 @@ func sanitizeEvent(event abcitypes.Event) abcitypes.Event {
 		isValidJSON := (strings.HasPrefix(value, "{") || strings.HasPrefix(value, "[")) &&
 			json.Valid([]byte(value))
 		if !isValidJSON {
-			value = fmt.Sprintf("\"%s\"", value)
+			// Use json.Marshal to properly escape special characters (quotes,
+			// backslashes, control chars) in user-controlled strings.
+			quoted, err := json.Marshal(value)
+			if err != nil {
+				value = fmt.Sprintf("\"%s\"", value)
+			} else {
+				value = string(quoted)
+			}
 		}
 
 		sanitizedAttrs[i] = abcitypes.EventAttribute{

--- a/internal/services/events.go
+++ b/internal/services/events.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"slices"
 	"strings"
@@ -359,10 +360,14 @@ func sanitizeEvent(event abcitypes.Event) abcitypes.Event {
 	for i, attr := range event.Attributes {
 		// Remove any extra quotes and ensure proper JSON formatting
 		value := strings.Trim(attr.Value, "\"")
-		// If the value isn't already a JSON value (object, array, or quoted string),
-		// wrap it in quotes
-		isArray := strings.HasPrefix(value, "[") && strings.HasSuffix(value, "]")
-		if !strings.HasPrefix(value, "{") && !isArray {
+		// Only treat the value as a JSON object/array if it is actually valid JSON.
+		// A naive prefix check (e.g. starts with '{') is insufficient because
+		// arbitrary user-controlled strings (such as a finality provider moniker)
+		// can start with '{' or '[' without being valid JSON, which would cause
+		// sdk.ParseTypedEvent to fail and permanently stall the indexer.
+		isValidJSON := (strings.HasPrefix(value, "{") || strings.HasPrefix(value, "[")) &&
+			json.Valid([]byte(value))
+		if !isValidJSON {
 			value = fmt.Sprintf("\"%s\"", value)
 		}
 

--- a/internal/services/events_test.go
+++ b/internal/services/events_test.go
@@ -40,6 +40,14 @@ func Test_sanitizeEvent(t *testing.T) {
 			name:  "Moniker value starts with [",
 			event: `{"type":"babylon.btcstaking.v1.EventFinalityProviderEdited","attributes":[{"key":"btc_pk_hex","value":"\"fc8a5b9930c3383e94bd940890e93cfcf95b2571ad50df8063b7011f120b918a\"","index":true},{"key":"commission","value":"\"0.030000000000000000\"","index":true},{"key":"details","value":"\"pSTAKE Finance is a multichain liquid staking protocol, backed by Binance Labs.\"","index":true},{"key":"identity","value":"\"CCD58C1559B694A8\"","index":true},{"key":"moniker","value":"\"[Deprecating on 10 Aug 25] pSTAKE Finance\"","index":true},{"key":"security_contact","value":"\"hello@pstake.finance\"","index":true},{"key":"website","value":"\"https://pstake.finance/\"","index":true},{"key":"msg_index","value":"0","index":true}]}`,
 		},
+		{
+			name:  "Moniker value starts with { (malicious - not valid JSON)",
+			event: `{"type":"babylon.btcstaking.v1.EventFinalityProviderEdited","attributes":[{"key":"btc_pk_hex","value":"\"fc8a5b9930c3383e94bd940890e93cfcf95b2571ad50df8063b7011f120b918a\"","index":true},{"key":"commission","value":"\"0.030000000000000000\"","index":true},{"key":"details","value":"\"some details\"","index":true},{"key":"identity","value":"\"\"","index":true},{"key":"moniker","value":"\"{evil_moniker\"","index":true},{"key":"security_contact","value":"\"\"","index":true},{"key":"website","value":"\"\"","index":true},{"key":"msg_index","value":"0","index":true}]}`,
+		},
+		{
+			name:  "Moniker value starts with [ but is not valid JSON array",
+			event: `{"type":"babylon.btcstaking.v1.EventFinalityProviderEdited","attributes":[{"key":"btc_pk_hex","value":"\"fc8a5b9930c3383e94bd940890e93cfcf95b2571ad50df8063b7011f120b918a\"","index":true},{"key":"commission","value":"\"0.030000000000000000\"","index":true},{"key":"details","value":"\"some details\"","index":true},{"key":"identity","value":"\"\"","index":true},{"key":"moniker","value":"\"[not an array\"","index":true},{"key":"security_contact","value":"\"\"","index":true},{"key":"website","value":"\"\"","index":true},{"key":"msg_index","value":"0","index":true}]}`,
+		},
 	}
 
 	for _, cse := range cases {

--- a/internal/services/sanitize_event_test.go
+++ b/internal/services/sanitize_event_test.go
@@ -1,11 +1,11 @@
 package services
 
 import (
+	"encoding/json"
 	"testing"
 
 	abcitypes "github.com/cometbft/cometbft/abci/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -62,6 +62,16 @@ func Test_sanitizeEvent_MaliciousValues(t *testing.T) {
 			name:         "moniker that looks like JSON but is a string field",
 			monikerValue: `"{\"key\":\"value\"}"`,
 		},
+		{
+			// Moniker containing a literal double quote — json.Marshal must
+			// escape it properly so ParseTypedEvent doesn't choke.
+			name:         "moniker with embedded double quote",
+			monikerValue: `"bad\"moniker"`,
+		},
+		{
+			name:         "moniker with backslash",
+			monikerValue: `"back\\slash"`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -75,13 +85,13 @@ func Test_sanitizeEvent_MaliciousValues(t *testing.T) {
 			_, err := sdk.ParseTypedEvent(sanitized)
 			require.NoError(t, err, "ParseTypedEvent should not fail on sanitized event")
 
-			// Verify the moniker attribute is valid JSON after sanitization
+			// Moniker is a protobuf string field, so after sanitization it must
+			// always be a quoted JSON string — never a raw JSON object or array.
 			for _, attr := range sanitized.Attributes {
 				if attr.Key == "moniker" {
-					assert.True(t,
-						(attr.Value[0] == '"') || (attr.Value[0] == '{') || (attr.Value[0] == '['),
-						"moniker value should be a valid JSON token, got: %s", attr.Value,
-					)
+					var moniker string
+					require.NoError(t, json.Unmarshal([]byte(attr.Value), &moniker),
+						"moniker should unmarshal as a JSON string, got: %s", attr.Value)
 				}
 			}
 		})

--- a/internal/services/sanitize_event_test.go
+++ b/internal/services/sanitize_event_test.go
@@ -1,0 +1,89 @@
+package services
+
+import (
+	"testing"
+
+	abcitypes "github.com/cometbft/cometbft/abci/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_sanitizeEvent_MaliciousValues(t *testing.T) {
+	// Base event template: a valid EventFinalityProviderEdited with a placeholder moniker.
+	// The moniker value is replaced per test case.
+	makeEvent := func(monikerValue string) abcitypes.Event {
+		return abcitypes.Event{
+			Type: "babylon.btcstaking.v1.EventFinalityProviderEdited",
+			Attributes: []abcitypes.EventAttribute{
+				{Key: "btc_pk_hex", Value: `"fc8a5b9930c3383e94bd940890e93cfcf95b2571ad50df8063b7011f120b918a"`},
+				{Key: "commission", Value: `"0.030000000000000000"`},
+				{Key: "details", Value: `"some details"`},
+				{Key: "identity", Value: `""`},
+				{Key: "moniker", Value: monikerValue},
+				{Key: "security_contact", Value: `""`},
+				{Key: "website", Value: `""`},
+				{Key: "msg_index", Value: "0"},
+			},
+		}
+	}
+
+	tests := []struct {
+		name         string
+		monikerValue string
+	}{
+		{
+			name:         "normal moniker",
+			monikerValue: `"my-validator"`,
+		},
+		{
+			name:         "moniker starting with { (not valid JSON)",
+			monikerValue: `"{evil_moniker"`,
+		},
+		{
+			name:         "moniker starting with [ (not valid JSON)",
+			monikerValue: `"[not an array"`,
+		},
+		{
+			name:         "moniker that is only {",
+			monikerValue: `"{"`,
+		},
+		{
+			name:         "moniker with curly braces inside",
+			monikerValue: `"{hello}{world}"`,
+		},
+		{
+			name:         "moniker starting with [ and ending with ]  but not JSON",
+			monikerValue: `"[Deprecating on 10 Aug 25] pSTAKE Finance"`,
+		},
+		{
+			// A moniker that happens to be valid JSON is still a string field in
+			// protobuf, so it must be quoted. The chain delivers it quoted.
+			name:         "moniker that looks like JSON but is a string field",
+			monikerValue: `"{\"key\":\"value\"}"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := makeEvent(tt.monikerValue)
+			sanitized := sanitizeEvent(event)
+
+			// The sanitized event must always be parseable by ParseTypedEvent.
+			// Before the fix, monikers starting with '{' or '[' that aren't valid
+			// JSON would be left unquoted, causing ParseTypedEvent to fail.
+			_, err := sdk.ParseTypedEvent(sanitized)
+			require.NoError(t, err, "ParseTypedEvent should not fail on sanitized event")
+
+			// Verify the moniker attribute is valid JSON after sanitization
+			for _, attr := range sanitized.Attributes {
+				if attr.Key == "moniker" {
+					assert.True(t,
+						(attr.Value[0] == '"') || (attr.Value[0] == '{') || (attr.Value[0] == '['),
+						"moniker value should be a valid JSON token, got: %s", attr.Value,
+					)
+				}
+			}
+		})
+	}
+}

--- a/internal/services/subscription.go
+++ b/internal/services/subscription.go
@@ -41,7 +41,7 @@ func (s *Service) SubscribeToBbnEvents(ctx context.Context) error {
 		return fmt.Errorf("failed to subscribe to events: %w", err)
 	}
 
-	go func() {
+	go func() { //nolint:gosec // G118: goroutine intentionally outlives the caller; ctx is used for cancellation
 		for {
 			select {
 			case event := <-eventChan:

--- a/internal/services/watch_btc_events.go
+++ b/internal/services/watch_btc_events.go
@@ -600,7 +600,7 @@ func (s *Service) isSpendingStakingTxUnbondingPath(
 		return false, err
 	}
 
-	if int(delegation.StakingOutputIdx) >= len(stakingTx.TxOut) {
+	if uint64(delegation.StakingOutputIdx) >= uint64(len(stakingTx.TxOut)) {
 		return false, fmt.Errorf("staking output index %d out of range (tx has %d outputs)", delegation.StakingOutputIdx, len(stakingTx.TxOut))
 	}
 	stakingValue := btcutil.Amount(stakingTx.TxOut[delegation.StakingOutputIdx].Value)
@@ -677,7 +677,7 @@ func (s *Service) validateUnbondingTxOutput(ctx context.Context, tx *wire.MsgTx,
 		return false, err
 	}
 
-	if int(delegation.StakingOutputIdx) >= len(stakingTx.TxOut) {
+	if uint64(delegation.StakingOutputIdx) >= uint64(len(stakingTx.TxOut)) {
 		return false, fmt.Errorf("staking output index %d out of range (tx has %d outputs)", delegation.StakingOutputIdx, len(stakingTx.TxOut))
 	}
 	stakingValue := btcutil.Amount(stakingTx.TxOut[delegation.StakingOutputIdx].Value)
@@ -791,7 +791,7 @@ func (s *Service) isSpendingStakingTxTimeLockPath(ctx context.Context, tx *wire.
 		return false, fmt.Errorf("failed to deserialize staking tx: %w", err)
 	}
 
-	if int(delegation.StakingOutputIdx) >= len(stakingTx.TxOut) {
+	if uint64(delegation.StakingOutputIdx) >= uint64(len(stakingTx.TxOut)) {
 		return false, fmt.Errorf("staking output index %d out of range (tx has %d outputs)", delegation.StakingOutputIdx, len(stakingTx.TxOut))
 	}
 	stakingValue := btcutil.Amount(stakingTx.TxOut[delegation.StakingOutputIdx].Value)
@@ -873,7 +873,7 @@ func (s *Service) isSpendingUnbondingTxTimeLockPath(
 
 	// re-build the time-lock path script and check whether the script from
 	// the witness matches
-	if int(delegation.StakingOutputIdx) >= len(stakingTx.TxOut) {
+	if uint64(delegation.StakingOutputIdx) >= uint64(len(stakingTx.TxOut)) {
 		return false, fmt.Errorf("staking output index %d out of range (tx has %d outputs)", delegation.StakingOutputIdx, len(stakingTx.TxOut))
 	}
 	stakingValue := btcutil.Amount(stakingTx.TxOut[delegation.StakingOutputIdx].Value)
@@ -946,7 +946,7 @@ func (s *Service) isSpendingStakingTxSlashingPath(ctx context.Context, tx *wire.
 		return false, fmt.Errorf("failed to deserialize staking tx: %w", err)
 	}
 
-	if int(delegation.StakingOutputIdx) >= len(stakingTx.TxOut) {
+	if uint64(delegation.StakingOutputIdx) >= uint64(len(stakingTx.TxOut)) {
 		return false, fmt.Errorf("staking output index %d out of range (tx has %d outputs)", delegation.StakingOutputIdx, len(stakingTx.TxOut))
 	}
 	stakingValue := btcutil.Amount(stakingTx.TxOut[delegation.StakingOutputIdx].Value)
@@ -1023,7 +1023,7 @@ func (s *Service) isSpendingUnbondingTxSlashingPath(ctx context.Context, tx *wir
 
 	// re-build the time-lock path script and check whether the script from
 	// the witness matches
-	if int(delegation.StakingOutputIdx) >= len(stakingTx.TxOut) {
+	if uint64(delegation.StakingOutputIdx) >= uint64(len(stakingTx.TxOut)) {
 		return false, fmt.Errorf("staking output index %d out of range (tx has %d outputs)", delegation.StakingOutputIdx, len(stakingTx.TxOut))
 	}
 	stakingValue := btcutil.Amount(stakingTx.TxOut[delegation.StakingOutputIdx].Value)
@@ -1066,7 +1066,7 @@ func (s *Service) isSpendingUnbondingTxSlashingPath(ctx context.Context, tx *wir
 // from a transaction input's witness stack, with bounds checking on both the
 // input index and the witness length.
 func extractScriptFromWitness(tx *wire.MsgTx, inputIdx uint32) ([]byte, error) {
-	if int(inputIdx) >= len(tx.TxIn) {
+	if uint64(inputIdx) >= uint64(len(tx.TxIn)) {
 		return nil, fmt.Errorf("input index %d out of range (tx has %d inputs)", inputIdx, len(tx.TxIn))
 	}
 	witness := tx.TxIn[inputIdx].Witness

--- a/internal/services/watch_btc_events.go
+++ b/internal/services/watch_btc_events.go
@@ -513,6 +513,10 @@ func (s *Service) startWatchingSlashingChange(
 		return fmt.Errorf("failed to save timelock expire: %w", err)
 	}
 
+	if len(slashingTx.TxOut) < 2 {
+		return fmt.Errorf("slashing tx has %d outputs, expected at least 2", len(slashingTx.TxOut))
+	}
+
 	go func() {
 		// Register spend notification for the change output
 		spendEv, err := s.btcNotifier.RegisterSpendNtfn(
@@ -558,6 +562,9 @@ func (s *Service) isSpendingStakingTxUnbondingPath(
 	}
 
 	// 2. an unbonding tx must spend the staking output
+	if len(tx.TxIn) == 0 {
+		return false, fmt.Errorf("spending tx has no inputs")
+	}
 	if !tx.TxIn[0].PreviousOutPoint.Hash.IsEqual(&stakingTxHash) {
 		return false, nil
 	}
@@ -593,6 +600,9 @@ func (s *Service) isSpendingStakingTxUnbondingPath(
 		return false, err
 	}
 
+	if int(delegation.StakingOutputIdx) >= len(stakingTx.TxOut) {
+		return false, fmt.Errorf("staking output index %d out of range (tx has %d outputs)", delegation.StakingOutputIdx, len(stakingTx.TxOut))
+	}
 	stakingValue := btcutil.Amount(stakingTx.TxOut[delegation.StakingOutputIdx].Value)
 
 	// 3. re-build the unbonding path script and check whether the script from
@@ -614,12 +624,10 @@ func (s *Service) isSpendingStakingTxUnbondingPath(
 		return false, fmt.Errorf("failed to get the unbonding path spend info: %w", err)
 	}
 
-	witness := tx.TxIn[0].Witness
-	if len(witness) < 2 {
-		panic(fmt.Errorf("spending tx should have at least 2 elements in witness, got %d", len(witness)))
+	scriptFromWitness, err := extractScriptFromWitness(tx, 0)
+	if err != nil {
+		return false, err
 	}
-
-	scriptFromWitness := tx.TxIn[0].Witness[len(tx.TxIn[0].Witness)-2]
 
 	if !bytes.Equal(unbondingPathInfo.GetPkScriptPath(), scriptFromWitness) {
 		// not unbonding tx as it does not unlock the unbonding path
@@ -669,11 +677,17 @@ func (s *Service) validateUnbondingTxOutput(ctx context.Context, tx *wire.MsgTx,
 		return false, err
 	}
 
+	if int(delegation.StakingOutputIdx) >= len(stakingTx.TxOut) {
+		return false, fmt.Errorf("staking output index %d out of range (tx has %d outputs)", delegation.StakingOutputIdx, len(stakingTx.TxOut))
+	}
 	stakingValue := btcutil.Amount(stakingTx.TxOut[delegation.StakingOutputIdx].Value)
 
 	log := log.Ctx(ctx)
 
 	// Validate transaction sequence and locktime
+	if len(tx.TxIn) == 0 {
+		return false, fmt.Errorf("spending tx has no inputs")
+	}
 	if tx.TxIn[0].Sequence != wire.MaxTxInSequenceNum || tx.LockTime != 0 {
 		log.Debug().
 			Str("staking_tx", delegation.StakingTxHashHex).
@@ -705,6 +719,9 @@ func (s *Service) validateUnbondingTxOutput(ctx context.Context, tx *wire.MsgTx,
 	}
 
 	// Validate output script and value
+	if len(tx.TxOut) == 0 {
+		return false, fmt.Errorf("spending tx has no outputs")
+	}
 	if !bytes.Equal(tx.TxOut[0].PkScript, unbondingInfo.UnbondingOutput.PkScript) {
 		log.Debug().
 			Str("staking_tx", delegation.StakingTxHashHex).
@@ -774,6 +791,9 @@ func (s *Service) isSpendingStakingTxTimeLockPath(ctx context.Context, tx *wire.
 		return false, fmt.Errorf("failed to deserialize staking tx: %w", err)
 	}
 
+	if int(delegation.StakingOutputIdx) >= len(stakingTx.TxOut) {
+		return false, fmt.Errorf("staking output index %d out of range (tx has %d outputs)", delegation.StakingOutputIdx, len(stakingTx.TxOut))
+	}
 	stakingValue := btcutil.Amount(stakingTx.TxOut[delegation.StakingOutputIdx].Value)
 
 	// 3. re-build the timelock path script and check whether the script from
@@ -796,12 +816,10 @@ func (s *Service) isSpendingStakingTxTimeLockPath(ctx context.Context, tx *wire.
 		return false, fmt.Errorf("failed to get the unbonding path spend info: %w", err)
 	}
 
-	witness := tx.TxIn[spendingInputIdx].Witness
-	if len(witness) < 2 {
-		panic(fmt.Errorf("spending tx should have at least 2 elements in witness, got %d", len(witness)))
+	scriptFromWitness, err := extractScriptFromWitness(tx, spendingInputIdx)
+	if err != nil {
+		return false, err
 	}
-
-	scriptFromWitness := tx.TxIn[spendingInputIdx].Witness[len(tx.TxIn[spendingInputIdx].Witness)-2]
 
 	if !bytes.Equal(timelockPathInfo.GetPkScriptPath(), scriptFromWitness) {
 		log.Ctx(ctx).Debug().
@@ -855,6 +873,9 @@ func (s *Service) isSpendingUnbondingTxTimeLockPath(
 
 	// re-build the time-lock path script and check whether the script from
 	// the witness matches
+	if int(delegation.StakingOutputIdx) >= len(stakingTx.TxOut) {
+		return false, fmt.Errorf("staking output index %d out of range (tx has %d outputs)", delegation.StakingOutputIdx, len(stakingTx.TxOut))
+	}
 	stakingValue := btcutil.Amount(stakingTx.TxOut[delegation.StakingOutputIdx].Value)
 	unbondingFee := btcutil.Amount(params.UnbondingFeeSat)
 	expectedUnbondingOutputValue := stakingValue - unbondingFee
@@ -875,12 +896,10 @@ func (s *Service) isSpendingUnbondingTxTimeLockPath(
 		return false, fmt.Errorf("failed to get the unbonding path spend info: %w", err)
 	}
 
-	witness := tx.TxIn[spendingInputIdx].Witness
-	if len(witness) < 2 {
-		panic(fmt.Errorf("spending tx should have at least 2 elements in witness, got %d", len(witness)))
+	scriptFromWitness, err := extractScriptFromWitness(tx, spendingInputIdx)
+	if err != nil {
+		return false, err
 	}
-
-	scriptFromWitness := tx.TxIn[spendingInputIdx].Witness[len(tx.TxIn[spendingInputIdx].Witness)-2]
 
 	if !bytes.Equal(timelockPathInfo.GetPkScriptPath(), scriptFromWitness) {
 		log.Debug().
@@ -927,6 +946,9 @@ func (s *Service) isSpendingStakingTxSlashingPath(ctx context.Context, tx *wire.
 		return false, fmt.Errorf("failed to deserialize staking tx: %w", err)
 	}
 
+	if int(delegation.StakingOutputIdx) >= len(stakingTx.TxOut) {
+		return false, fmt.Errorf("staking output index %d out of range (tx has %d outputs)", delegation.StakingOutputIdx, len(stakingTx.TxOut))
+	}
 	stakingValue := btcutil.Amount(stakingTx.TxOut[delegation.StakingOutputIdx].Value)
 
 	// 3. re-build the unbonding path script and check whether the script from
@@ -949,12 +971,10 @@ func (s *Service) isSpendingStakingTxSlashingPath(ctx context.Context, tx *wire.
 		return false, fmt.Errorf("failed to get the slashing path spend info: %w", err)
 	}
 
-	witness := tx.TxIn[spendingInputIdx].Witness
-	if len(witness) < 2 {
-		panic(fmt.Errorf("spending tx should have at least 2 elements in witness, got %d", len(witness)))
+	scriptFromWitness, err := extractScriptFromWitness(tx, spendingInputIdx)
+	if err != nil {
+		return false, err
 	}
-
-	scriptFromWitness := tx.TxIn[spendingInputIdx].Witness[len(tx.TxIn[spendingInputIdx].Witness)-2]
 
 	if !bytes.Equal(slashingPathInfo.GetPkScriptPath(), scriptFromWitness) {
 		log.Ctx(ctx).Debug().
@@ -1003,6 +1023,9 @@ func (s *Service) isSpendingUnbondingTxSlashingPath(ctx context.Context, tx *wir
 
 	// re-build the time-lock path script and check whether the script from
 	// the witness matches
+	if int(delegation.StakingOutputIdx) >= len(stakingTx.TxOut) {
+		return false, fmt.Errorf("staking output index %d out of range (tx has %d outputs)", delegation.StakingOutputIdx, len(stakingTx.TxOut))
+	}
 	stakingValue := btcutil.Amount(stakingTx.TxOut[delegation.StakingOutputIdx].Value)
 	unbondingFee := btcutil.Amount(params.UnbondingFeeSat)
 	expectedUnbondingOutputValue := stakingValue - unbondingFee
@@ -1023,12 +1046,10 @@ func (s *Service) isSpendingUnbondingTxSlashingPath(ctx context.Context, tx *wir
 		return false, fmt.Errorf("failed to get the slashing path spend info: %w", err)
 	}
 
-	witness := tx.TxIn[spendingInputIdx].Witness
-	if len(witness) < 2 {
-		panic(fmt.Errorf("spending tx should have at least 2 elements in witness, got %d", len(witness)))
+	scriptFromWitness, err := extractScriptFromWitness(tx, spendingInputIdx)
+	if err != nil {
+		return false, err
 	}
-
-	scriptFromWitness := tx.TxIn[spendingInputIdx].Witness[len(tx.TxIn[spendingInputIdx].Witness)-2]
 
 	if !bytes.Equal(slashingPathInfo.GetPkScriptPath(), scriptFromWitness) {
 		log.Ctx(ctx).Debug().
@@ -1039,4 +1060,18 @@ func (s *Service) isSpendingUnbondingTxSlashingPath(ctx context.Context, tx *wir
 	}
 
 	return true, nil
+}
+
+// extractScriptFromWitness safely extracts the script (second-to-last element)
+// from a transaction input's witness stack, with bounds checking on both the
+// input index and the witness length.
+func extractScriptFromWitness(tx *wire.MsgTx, inputIdx uint32) ([]byte, error) {
+	if int(inputIdx) >= len(tx.TxIn) {
+		return nil, fmt.Errorf("input index %d out of range (tx has %d inputs)", inputIdx, len(tx.TxIn))
+	}
+	witness := tx.TxIn[inputIdx].Witness
+	if len(witness) < 2 {
+		return nil, fmt.Errorf("spending tx input %d has %d witness elements, expected at least 2", inputIdx, len(witness))
+	}
+	return witness[len(witness)-2], nil
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -114,7 +114,7 @@ func SerializeBtcTransaction(tx *wire.MsgTx) ([]byte, error) {
 }
 
 func GetWrappedTxs(msg *wire.MsgBlock) []*btcutil.Tx {
-	btcTxs := []*btcutil.Tx{}
+	btcTxs := make([]*btcutil.Tx, 0, len(msg.Transactions))
 
 	for i := range msg.Transactions {
 		newTx := btcutil.NewTx(msg.Transactions[i])


### PR DESCRIPTION
Harden event processing against malformed chain/BTC data that could
permanently stall the indexer or crash it via panics:

- sanitizeEvent: validate with json.Valid() instead of naive prefix check
- watch_btc_events: convert 5 panic() calls to error returns, add TxOut/TxIn bounds checks
- delegation_helpers: add TxOut bounds checks before slice access
- delegation model: add staking output index bounds check
- delegation: propagate ParseUint32 errors instead of silently ignoring them